### PR TITLE
Skiped flag.Parse as it interferes with the root command.

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -43,6 +43,7 @@ if [[ "${SOURCE_PATH}" != *"src/${REPOSITORY}" ]]; then
   export GOPATH="${SOURCE_PATH}/tmp"
   export GOBIN="${SOURCE_PATH}/tmp/bin"
   export PATH="${GOBIN}:${PATH}"
+  export GO111MODULE=on
 fi
 
 # Install Golint (linting tool).

--- a/.ci/test
+++ b/.ci/test
@@ -48,6 +48,7 @@ if [[ "${SOURCE_PATH}" != *"src/${REPOSITORY}" ]]; then
   export GOPATH="${SOURCE_PATH}/tmp"
   export GOBIN="${SOURCE_PATH}/tmp/bin"
   export PATH="${GOBIN}:${PATH}"
+  export GO111MODULE=on
 fi
 
 # Install Ginkgo (test framework) to be able to execute the tests.

--- a/cmd/probe.go
+++ b/cmd/probe.go
@@ -50,6 +50,8 @@ func init() {
 }
 
 func runProbe(cmd *cobra.Command, args []string) {
+	klog.V(5).Info("Running probe command")
+
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := setupSignalHandler()
 	deps, err := scaler.LoadProbeDependantsListFile(configFile)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,12 +100,12 @@ func init() {
 	rootCmd.Flags().StringVar(&strWatchDuration, "watch-duration", defaultWatchDuration, "The duration to watch dependencies after the service is ready.")
 
 	klog.InitFlags(nil)
-	flag.Parse()
+	flag.Set("logtostderr", "true")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
 
 func runRoot(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
+	klog.V(5).Info("Running root command")
 
 	watchDuration, err := time.ParseDuration(strWatchDuration)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed the command-line incompatibility for the root command introduced in the release [0.3.0](https://github.com/gardener/dependency-watchdog/releases/tag/0.3.0).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy user
Fixed the command-line incompatibility for the root command introduced in the release 0.3.0.
```
