### PR TITLE
Export types to make them reusable for other packages

### DIFF
--- a/pkg/restarter/restarter.go
+++ b/pkg/restarter/restarter.go
@@ -236,9 +236,9 @@ func (c *Controller) processEndpoint(ctx context.Context, key string) error {
 	return nil
 }
 
-func (c *Controller) shootPodsIfNecessary(ctx context.Context, namespace string, srv service) error {
+func (c *Controller) shootPodsIfNecessary(ctx context.Context, namespace string, srv Service) error {
 	for _, dependantPod := range srv.Dependants {
-		go func(depPods dependantPods) {
+		go func(depPods DependantPods) {
 			err := c.shootDependentPodsIfNecessary(ctx, namespace, &depPods)
 			if err != nil {
 				klog.Errorf("Error processing dependents pods: %s", err)
@@ -248,7 +248,7 @@ func (c *Controller) shootPodsIfNecessary(ctx context.Context, namespace string,
 	return nil
 }
 
-func (c *Controller) shootDependentPodsIfNecessary(ctx context.Context, namespace string, depPods *dependantPods) error {
+func (c *Controller) shootDependentPodsIfNecessary(ctx context.Context, namespace string, depPods *DependantPods) error {
 	selector, err := metav1.LabelSelectorAsSelector(depPods.Selector)
 	if err != nil {
 		return fmt.Errorf("error converting label selector to selector %s", depPods.Selector.String())

--- a/pkg/restarter/types.go
+++ b/pkg/restarter/types.go
@@ -40,15 +40,15 @@ type Controller struct {
 // ServiceDependants holds the service and the label selectors of the pods which has to be restarted when
 // the service becomes ready and the pods are in CrashloopBackoff.
 type ServiceDependants struct {
-	Services  map[string]service `json:"services"`
+	Services  map[string]Service `json:"services"`
 	Namespace string             `json:"namespace"`
 }
 
-type service struct {
-	Dependants []dependantPods `json:"dependantPods"`
+type Service struct {
+	Dependants []DependantPods `json:"dependantPods"`
 }
 
-type dependantPods struct {
+type DependantPods struct {
 	Name     string                `json:"name,omitempty"`
 	Selector *metav1.LabelSelector `json:"selector"`
 }

--- a/pkg/restarter/types.go
+++ b/pkg/restarter/types.go
@@ -49,6 +49,7 @@ type Service struct {
 	Dependants []DependantPods `json:"dependantPods"`
 }
 
+// DependantPods struct captures the details needed to identify dependant pods.
 type DependantPods struct {
 	Name     string                `json:"name,omitempty"`
 	Selector *metav1.LabelSelector `json:"selector"`

--- a/pkg/restarter/types.go
+++ b/pkg/restarter/types.go
@@ -44,6 +44,7 @@ type ServiceDependants struct {
 	Namespace string             `json:"namespace"`
 }
 
+// Service struct defines the dependent pods of a service.
 type Service struct {
 	Dependants []DependantPods `json:"dependantPods"`
 }

--- a/pkg/scaler/prober.go
+++ b/pkg/scaler/prober.go
@@ -56,7 +56,7 @@ type prober struct {
 	clusterLister     gardenerlisterv1alpha1.ClusterLister
 	deploymentsLister listerappsv1.DeploymentLister
 	scaleInterface    scale.ScaleInterface
-	probeDeps         *probeDependants
+	probeDeps         *ProbeDependants
 	initialDelay      time.Duration
 	initialDelayTimer *time.Timer
 	successThreshold  int32

--- a/pkg/scaler/prober_test.go
+++ b/pkg/scaler/prober_test.go
@@ -77,8 +77,8 @@ var _ = Describe("prober", func() {
 		p := &prober{
 			namespace:    ns,
 			secretLister: listerv1.NewSecretLister(indexer),
-			probeDeps: &probeDependants{
-				Probe: &probeConfig{
+			probeDeps: &ProbeDependants{
+				Probe: &ProbeConfig{
 					TimeoutSeconds: &timeout,
 				},
 			},

--- a/pkg/scaler/scaler.go
+++ b/pkg/scaler/scaler.go
@@ -239,7 +239,7 @@ func (c *Controller) processNamespace(key string) error {
 	for i := range c.probeDependantsList.Probes {
 		probeDeps := &c.probeDependantsList.Probes[i]
 
-		go func(ns string, pd *probeDependants) {
+		go func(ns string, pd *ProbeDependants) {
 			p := &prober{
 				namespace:         ns,
 				mapper:            c.mapper,
@@ -286,7 +286,7 @@ func (c *Controller) processNamespace(key string) error {
 	return nil
 }
 
-func (c *Controller) getKey(ns string, probeDeps *probeDependants) string {
+func (c *Controller) getKey(ns string, probeDeps *ProbeDependants) string {
 	return ns + "/" + probeDeps.Name
 }
 
@@ -337,7 +337,7 @@ func (c *Controller) deleteProber(key string) {
 	delete(c.probers, key)
 }
 
-func (c *Controller) newContext(ns string, probeDeps *probeDependants) (context.Context, context.CancelFunc) {
+func (c *Controller) newContext(ns string, probeDeps *ProbeDependants) (context.Context, context.CancelFunc) {
 	key := c.getKey(ns, probeDeps)
 
 	ctx, cancelFn := context.WithCancel(context.Background())

--- a/pkg/scaler/types.go
+++ b/pkg/scaler/types.go
@@ -54,19 +54,19 @@ type Controller struct {
 // corresponding dependant Scales are scaled down to `zero`. They are scaled back to their
 // original scale when the external probe succeeds again.
 type ProbeDependantsList struct {
-	Probes    []probeDependants `json:"probes"`
+	Probes    []ProbeDependants `json:"probes"`
 	Namespace string            `json:"namespace"`
 }
 
-type probeDependants struct {
+type ProbeDependants struct {
 	Name            string                   `json:"name"`
-	Probe           *probeConfig             `json:"probe"`
-	DependantScales []*dependantScaleDetails `json:"dependantScales"`
+	Probe           *ProbeConfig             `json:"probe"`
+	DependantScales []*DependantScaleDetails `json:"dependantScales"`
 }
 
-type probeConfig struct {
-	External            *probeDetails `json:"external,omitempty"`
-	Internal            *probeDetails `json:"internal,omitempty"`
+type ProbeConfig struct {
+	External            *ProbeDetails `json:"external,omitempty"`
+	Internal            *ProbeDetails `json:"internal,omitempty"`
 	InitialDelaySeconds *int32        `json:"initialDelaySeconds,omitempty"`
 	TimeoutSeconds      *int32        `json:"timeoutSeconds,omitempty"`
 	PeriodSeconds       *int32        `json:"periodSeconds,omitempty"`
@@ -74,11 +74,11 @@ type probeConfig struct {
 	FailureThreshold    *int32        `json:"failureThreshold,omitempty"`
 }
 
-type probeDetails struct {
+type ProbeDetails struct {
 	KubeconfigSecretName string `json:"kubeconfigSecretName"`
 }
 
-type dependantScaleDetails struct {
+type DependantScaleDetails struct {
 	ScaleRef autoscaling.CrossVersionObjectReference `json:"scaleRef"`
 	Replicas *int32                                  `json:"replicas"`
 }

--- a/pkg/scaler/types.go
+++ b/pkg/scaler/types.go
@@ -58,6 +58,7 @@ type ProbeDependantsList struct {
 	Namespace string            `json:"namespace"`
 }
 
+// ProbeDependants struct captures the details about a probe and its dependant scale sub-resources.
 type ProbeDependants struct {
 	Name            string                   `json:"name"`
 	Probe           *ProbeConfig             `json:"probe"`

--- a/pkg/scaler/types.go
+++ b/pkg/scaler/types.go
@@ -65,6 +65,7 @@ type ProbeDependants struct {
 	DependantScales []*DependantScaleDetails `json:"dependantScales"`
 }
 
+// ProbeConfig struct captures the details for probing a Kubernetes apiserver.
 type ProbeConfig struct {
 	External            *ProbeDetails `json:"external,omitempty"`
 	Internal            *ProbeDetails `json:"internal,omitempty"`

--- a/pkg/scaler/types.go
+++ b/pkg/scaler/types.go
@@ -76,6 +76,7 @@ type ProbeConfig struct {
 	FailureThreshold    *int32        `json:"failureThreshold,omitempty"`
 }
 
+// ProbeDetails captures the kubeconfig secret details to probe a Kubernetes apiserver.
 type ProbeDetails struct {
 	KubeconfigSecretName string `json:"kubeconfigSecretName"`
 }

--- a/pkg/scaler/types.go
+++ b/pkg/scaler/types.go
@@ -81,6 +81,7 @@ type ProbeDetails struct {
 	KubeconfigSecretName string `json:"kubeconfigSecretName"`
 }
 
+// DependantScaleDetails has the details about the dependant scale sub-resource.
 type DependantScaleDetails struct {
 	ScaleRef autoscaling.CrossVersionObjectReference `json:"scaleRef"`
 	Replicas *int32                                  `json:"replicas"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Export types to make them reusable for other packages

/invite @amshuman-kr 
/squash

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```feature developer
Export types in `pkg/restarter` and `pkg/scaler` to make them reusable for other packages.
```
