### PR TITLE
Switch leader election to endpointleases

### DIFF
--- a/pkg/restarter/restarter.go
+++ b/pkg/restarter/restarter.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 
 	"github.com/gardener/dependency-watchdog/pkg/multicontext"
@@ -42,6 +43,9 @@ func NewController(clientset kubernetes.Interface,
 		serviceDependants: serviceDependants,
 		watchDuration:     watchDuration,
 		Multicontext:      multicontext.New(),
+		LeaderElection: componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+			ResourceLock: resourcelock.EndpointsLeasesResourceLock,
+		},
 	}
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&c.LeaderElection)
 	c.endpointInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/scaler/scaler.go
+++ b/pkg/scaler/scaler.go
@@ -13,6 +13,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 
 	"github.com/gardener/dependency-watchdog/pkg/multicontext"
@@ -54,6 +55,9 @@ func NewController(clientset kubernetes.Interface,
 		stopCh:                 stopCh,
 		probeDependantsList:    probeDependantsList,
 		Multicontext:           multicontext.New(),
+		LeaderElection: componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+			ResourceLock: resourcelock.EndpointsLeasesResourceLock,
+		},
 	}
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&c.LeaderElection)
 	c.clusterInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
Switch default leader election resource lock from `endpoints` to `endpointsleases`

**Which issue(s) this PR fixes**:
Part of #4742

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Switch default leader election resource lock for `dependency-watchdog` from `endpoints` to `endpointsleases`
```

```
Components that deploy the `dependency-watchdog` will now have to adapt the RBAC rules to allow `dependency-watchdog` to maintain its leader election resource lock in `leases` as well.
```
