### PR TITLE
Switch leader election to `leases`

### DIFF
--- a/pkg/restarter/restarter.go
+++ b/pkg/restarter/restarter.go
@@ -44,7 +44,7 @@ func NewController(clientset kubernetes.Interface,
 		watchDuration:     watchDuration,
 		Multicontext:      multicontext.New(),
 		LeaderElection: componentbaseconfigv1alpha1.LeaderElectionConfiguration{
-			ResourceLock: resourcelock.EndpointsLeasesResourceLock,
+			ResourceLock: resourcelock.LeasesResourceLock,
 		},
 	}
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&c.LeaderElection)

--- a/pkg/scaler/scaler.go
+++ b/pkg/scaler/scaler.go
@@ -56,7 +56,7 @@ func NewController(clientset kubernetes.Interface,
 		probeDependantsList:    probeDependantsList,
 		Multicontext:           multicontext.New(),
 		LeaderElection: componentbaseconfigv1alpha1.LeaderElectionConfiguration{
-			ResourceLock: resourcelock.EndpointsLeasesResourceLock,
+			ResourceLock: resourcelock.LeasesResourceLock,
 		},
 	}
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&c.LeaderElection)


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch default leader election resource lock from endpointsleases to leases.

**Which issue(s) this PR fixes**:
[Part of gardener/gardener #4742 ](https://github.com/gardener/gardener/issues/4742)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Switch default leader election resource lock for `dependency-watchdog` from `endpointsleases` to `leases`.
```
