### PR TITLE
[rel-0.7.0] Automated cherry pick of #44: Switch leader election to `leases`

### DIFF
--- a/pkg/restarter/restarter.go
+++ b/pkg/restarter/restarter.go
@@ -44,7 +44,7 @@ func NewController(clientset kubernetes.Interface,
 		watchDuration:     watchDuration,
 		Multicontext:      multicontext.New(),
 		LeaderElection: componentbaseconfigv1alpha1.LeaderElectionConfiguration{
-			ResourceLock: resourcelock.EndpointsLeasesResourceLock,
+			ResourceLock: resourcelock.LeasesResourceLock,
 		},
 	}
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&c.LeaderElection)

--- a/pkg/scaler/scaler.go
+++ b/pkg/scaler/scaler.go
@@ -56,7 +56,7 @@ func NewController(clientset kubernetes.Interface,
 		probeDependantsList:    probeDependantsList,
 		Multicontext:           multicontext.New(),
 		LeaderElection: componentbaseconfigv1alpha1.LeaderElectionConfiguration{
-			ResourceLock: resourcelock.EndpointsLeasesResourceLock,
+			ResourceLock: resourcelock.LeasesResourceLock,
 		},
 	}
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&c.LeaderElection)


### PR DESCRIPTION
Cherry pick of #44 on rel-0.7.0.

#44: Switch leader election to `leases`

**Release Notes:**
```improvement operator
Switch default leader election resource lock for `dependency-watchdog` from `endpointsleases` to `leases`.
```