### PR TITLE
fix for issue #55

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.15
+FROM alpine:3.15.4
 
 RUN apk add --update bash curl
 

--- a/pkg/scaler/api/types.go
+++ b/pkg/scaler/api/types.go
@@ -30,6 +30,7 @@ type ProbeConfig struct {
 	Internal            *ProbeDetails `json:"internal,omitempty"`
 	InitialDelaySeconds *int32        `json:"initialDelaySeconds,omitempty"`
 	TimeoutSeconds      *int32        `json:"timeoutSeconds,omitempty"`
+	ProbeTimeoutSeconds *int32        `json:"probeTimeoutSeconds,omitempty"`
 	PeriodSeconds       *int32        `json:"periodSeconds,omitempty"`
 	SuccessThreshold    *int32        `json:"successThreshold,omitempty"`
 	FailureThreshold    *int32        `json:"failureThreshold,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Adjust the probe timeout to be in sync with the kubelet timeout to update its lease.
**Which issue(s) this PR fixes**:
Fixes #55 

**Special notes for your reviewer**:

**Release note**:

<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```bug operator
Increased DWD probe timeout to be aligned with the kubelet timeout.
```
