### PR TITLE
Build Multi-Arch Images 📦

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -55,21 +55,9 @@ VERSION_FILE="$(${READLINK_BIN}  -f "${SOURCE_PATH}/VERSION")"
 VERSION="$(cat "${VERSION_FILE}")"
 GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 
-# If no LOCAL_BUILD environment variable is set, we configure the `go build` command
-# to build for linux OS, amd64 architectures and without CGO enablement.
-if [[ -z "$LOCAL_BUILD" ]]; then
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
-    -a \
-    -mod vendor \
-    -v \
-    -o "${BINARY_PATH}/linux-amd64/dependency-watchdog" \
-    main.go
+CGO_ENABLED=0 GO111MODULE=on go build \
+  -mod vendor \
+  -v \
+  -o "${BINARY_PATH}/dependency-watchdog" \
+  main.go
 
-# If the LOCAL_BUILD environment variable is set, we simply run `go build`.
-else
-  GO111MODULE=on go build \
-    -mod vendor \
-    -v \
-    -o "${BINARY_PATH}/dependency-watchdog" \
-    main.go
-fi

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -11,6 +11,10 @@ dependency-watchdog:
           'inject-commit-hash'
         inject_effective_version: true
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           dependency-watchdog:
             registry: 'gcr-readwrite'

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ build-local:
 
 .PHONY: docker-image
 docker-image: 
-	@if [[ ! -f $(BIN_DIR)/linux-amd64/dependency-watchdog ]]; then echo "No binary found. Please run 'make build'"; false; fi
 	@docker build -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) -f $(BUILD_DIR)/Dockerfile --rm .
 
 .PHONY: docker-push

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,10 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+From golang:1.18.3 as builder
+
+WORKDIR /go/src/github.com/gardener/dependency-watchdog
+COPY . .
+
+RUN make build
+
 FROM alpine:3.15.4
 
 RUN apk add --update bash curl
 
-COPY ./bin/linux-amd64/dependency-watchdog /usr/local/bin/dependency-watchdog
+COPY --from=builder /go/src/github.com/gardener/dependency-watchdog/bin/dependency-watchdog /usr/local/bin/dependency-watchdog
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/dependency-watchdog"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR lets the CI pipeline build multi-arch images with support for `linux/amd64` and `linux/arm64`.

**Which issue(s) this PR fixes**:
Fixes parts of https://github.com/gardener/gardener/issues/6258

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Published docker images for Dependency-Watchdog are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```
