### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,10 +9,8 @@ COPY . .
 
 RUN make build
 
-FROM alpine:3.15.4
+FROM gcr.io/distroless/static-debian11:nonroot
 
-RUN apk add --update bash curl
-
-COPY --from=builder /go/src/github.com/gardener/dependency-watchdog/bin/dependency-watchdog /usr/local/bin/dependency-watchdog
+COPY --from=builder /go/src/github.com/gardener/dependency-watchdog/bin/dependency-watchdog /dependency-watchdog
 WORKDIR /
-ENTRYPOINT ["/usr/local/bin/dependency-watchdog"]
+ENTRYPOINT ["/dependency-watchdog"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the base image from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The process will now use a non root user for its execution. This will reduce the attack surface of the images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
The `dependency-watchdog` now uses `distroless` instead of `alpine` as a base image.
```
