### PR TITLE
Fix for Issue#61

### DIFF
--- a/pkg/scaler/httputil.go
+++ b/pkg/scaler/httputil.go
@@ -1,0 +1,38 @@
+package scaler
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	"net/http"
+)
+
+type transportWrapper struct {
+	Transport http.RoundTripper
+}
+
+func (rt *transportWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
+	klog.Infof("(transportWrapper)(RoundTrip) request: %v", req.URL.String())
+	return rt.Transport.RoundTrip(req)
+}
+
+func DisableKeepAlive(config *rest.Config) error {
+	transport, err := createTransportWithDisableKeepAlive(config)
+	if err != nil {
+		return err
+	}
+	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &transportWrapper{Transport: transport}
+	})
+	return nil
+}
+
+func createTransportWithDisableKeepAlive(config *rest.Config) (*http.Transport, error) {
+	tlsConfig, err := rest.TLSConfigFor(config)
+	if err != nil {
+		return nil, err
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableKeepAlives = true
+	transport.TLSClientConfig = tlsConfig
+	return transport, nil
+}

--- a/pkg/scaler/httputil_test.go
+++ b/pkg/scaler/httputil_test.go
@@ -1,0 +1,58 @@
+package scaler
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"net/http"
+)
+
+var (
+	kubeConfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    name: test
+    certificate-authority-date: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvRENDQW9nQ0NRQ1NWMElyenhoaEdUQU5CZ2txaGtpRzl3MEJBUXNGQURDQmtERUxNQWtHQTFVRUJoTUMKUkVVeEdqQVlCZ05WQkFnTUVVSmhaR1Z1TFZkMWNuUjBaVzFpWlhKbk1SRXdEd1lEVlFRSERBaFhZV3hzWkc5eQpaakVQTUEwR0ExVUVDZ3dHVTBGUUlGTkZNUkV3RHdZRFZRUUxEQWhIWVhKa1pXNWxjakVQTUEwR0ExVUVBd3dHClkyRjBaWE4wTVIwd0d3WUpLb1pJaHZjTkFRa0JGZzVqWVhSbGMzUkFjMkZ3TG1OdmJUQWdGdzB5TWpBNE1ERXcKTmpRNU1qQmFHQTh6TURJeE1USXdNakEyTkRreU1Gb3dnWkF4Q3pBSkJnTlZCQVlUQWtSRk1Sb3dHQVlEVlFRSQpEQkZDWVdSbGJpMVhkWEowZEdWdFltVnlaekVSTUE4R0ExVUVCd3dJVjJGc2JHUnZjbVl4RHpBTkJnTlZCQW9NCkJsTkJVQ0JUUlRFUk1BOEdBMVVFQ3d3SVIyRnlaR1Z1WlhJeER6QU5CZ05WQkFNTUJtTmhkR1Z6ZERFZE1Cc0cKQ1NxR1NJYjNEUUVKQVJZT1kyRjBaWE4wUUhOaGNDNWpiMjB3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQgpEd0F3Z2dFS0FvSUJBUURHaUFTNGJFVlFUMm1LM000TlFVaW1iRnRiRE5JU2NkdDNUWWpUcVk0WGZXd09vRXFnCjdyM2VnSFNoVEhxdGtqa1hqZjJJWW8yL05SL1gyelpmNFJHTWNORTc4RkhMdVQ2QkltNHdVTXdIMU9sWkY0R2cKRjRaT0cvckt3dlNOTndJUThhczRZbmo1d1lHUWpBaVZjRm5SUkNjajFGd2dnalpMQklzeVRNd1laV2EyWHRCbQpOL0lENHc0QkZ4T3NlZ3JhK1hSQWt4dm5SMCtOd0xHbkNjM1hWVGpTWEFzc1oraVdYMFozc1hIRFZQd3U0bTg0Cm9ocTVFbXFoZ21wQ0ZVOEYvSVBmRDFkektDTFZNWVdOQkJqSTBXSFQweHlLZTBlRXd5NFVVN0VNSGdMTU5EeXcKRnllRGt4L1UyRDZYK2RJaFpYOTh6d0NCdktvQlh2Q0ZsTzJaQWdNQkFBRXdEUVlKS29aSWh2Y05BUUVMQlFBRApnZ0VCQUdYM3Vod0xKSGxhNUU2UDBiUlA4QmJiZ25pUDB3VURydUw4RXJxZXZ0SWRZOW5MSFRXV05QcXFSVlQrCjRydFJ5b0ZZSGxzVm9ycE5wQ250RmhKYkJYM05hTGhFQjJlamROVmx3VXlVaUV6WktES09XN1I4YzY3czY0SE8Ka0dUTjJhcFV3TGhoNlZnVkFneHROdmp6dXo1QTRLM0pQV1I4emZYUzJZbVdNcVZIZ1plQi9UeFdyaTRXRkdUSgpmV2FtZVg4YlhXRFE3dWdBMnFlMkw3R1EycWxSaVN0THpsRm1yR1VKaUx0ZEZ0cnFEK0VHdmM4MTlDNUgxOURQClFYV1ZxanVndDJmTEFaMW56VmhsQWowT2lqQ29PbVZWdjl0ZUpCQVhyK1Fjc2RTc21vKzFuZTlpazJLak5oVzQKdk0xQklNajE4dmpaaWR5UDBvZitkODZnT0hFPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    server: https://kube-apiserver.shoot--test--local.svc
+contexts:
+- context:
+    cluster: shoot--test--local
+    user: admin
+  name: shoot--test--local
+users:
+- name: admin
+  user:
+    username: admin
+    password: admin@bingo
+`
+)
+
+var _ = Describe("Checking KeepAlive setting on rest.config", func() {
+	var config *rest.Config
+	BeforeEach(func() {
+		clientConfig, err := clientcmd.NewClientConfigFromBytes([]byte(kubeConfig))
+		Expect(err).To(BeNil())
+		config, err = clientConfig.ClientConfig()
+		Expect(err).To(BeNil())
+	})
+	It("defaults to KeepAlive enabled", func() {
+		roundTripper, err := rest.TransportFor(config)
+		Expect(err).To(BeNil())
+		transport := roundTripper.(*http.Transport)
+		Expect(transport).ToNot(BeNil())
+		Expect(transport.DisableKeepAlives).To(BeFalse())
+	})
+	It("can set KeepAlive to disabled", func() {
+		err := DisableKeepAlive(config)
+		Expect(err).To(BeNil())
+		roundTripper, err := rest.TransportFor(config)
+		Expect(err).To(BeNil())
+		tw := roundTripper.(*transportWrapper)
+		Expect(tw).ToNot(BeNil())
+		t := tw.Transport.(*http.Transport)
+		Expect(t).ToNot(BeNil())
+		Expect(t.DisableKeepAlives).To(BeTrue())
+	})
+})

--- a/pkg/scaler/prober.go
+++ b/pkg/scaler/prober.go
@@ -144,7 +144,7 @@ func (p *prober) getClientFromSecret(secretName string, oldSHA []byte) (kubernet
 		return nil, nil, errors.New("Invalid empty kubeconfig")
 	}
 
-	newSHAArr := (sha256.Sum256(kubeconfig))
+	newSHAArr := sha256.Sum256(kubeconfig)
 	newSHA := newSHAArr[:]
 	if reflect.DeepEqual(oldSHA, newSHA) {
 		return nil, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "secret"}, secretName)
@@ -159,9 +159,11 @@ func (p *prober) getClientFromSecret(secretName string, oldSHA []byte) (kubernet
 	if err != nil {
 		return nil, newSHA, err
 	}
-
+	err = DisableKeepAlive(config)
+	if err != nil {
+		return nil, newSHA, err
+	}
 	config.Timeout = toDuration(p.probeDeps.Probe.ProbeTimeoutSeconds, defaultProbeTimeoutSeconds)
-
 	client, err := kubernetes.NewForConfig(config)
 	return client, newSHA, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Since DWD has no control over proper sending of TCP RST packets in case of a broken TCP connection, `KeepAlive=true` default configuration for the rest client causes re-use of the broken TCP connections which results in continuous failure of internal probes. This results in an incorrect scaling down of critical control plane components.

To prevent this the fix forcefully creates a new TCP connection for every internal and external probe. This is done by setting `DisableKeepAlive = `true` on the transport.

**Which issue(s) this PR fixes**:
Fixes #61 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
DWD client shall no longer use long running TCP connections when attempting to probe Kube ApiServer via internal endpoint.
```improvement operator

```
