### PR TITLE
change golangci go version to 1.19

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,7 @@
 run:
   concurrency: 4
   deadline: 10m
-  go: "1.17"
+  go: "1.19"
 
 linters:
   disable:


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the version of `.golangci.yaml` from 1.17 to 1.19 which is also the version used elsewhere.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
