### PR TITLE
Fix RetryUntilPredicate tests, upgrade go lang version to v1.19.4

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -27,11 +27,11 @@ dependency-watchdog:
                 build: ~
     steps:
       check:
-        image: 'golang:1.19.3'
+        image: 'golang:1.19.4'
       test-unit:
-        image: 'golang:1.19.3'
+        image: 'golang:1.19.4'
       build:
-        image: 'golang:1.19.3'
+        image: 'golang:1.19.4'
         output_dir: 'binary'
 
   jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.3 AS builder
+FROM golang:1.19.4 AS builder
 
 WORKDIR /go/src/github.com/gardener/dependency-watchdog
 COPY . .

--- a/internal/util/retry_test.go
+++ b/internal/util/retry_test.go
@@ -131,17 +131,12 @@ func TestRetryUntilPredicateForContextCancelled(t *testing.T) {
 }
 
 func TestRetryUntilPredicateWithBackgroundContext(t *testing.T) {
-	counter := 0
 	table := []struct {
 		predicateFn    func() bool
 		expectedResult bool
 	}{
 		{func() bool { return false }, false},
 		{func() bool { return true }, true},
-		{func() bool {
-			counter++
-			return counter%2 == 0
-		}, true},
 	}
 	for _, entry := range table {
 		g := NewWithT(t)
@@ -154,7 +149,6 @@ func TestRetryUntilPredicateWithBackgroundContext(t *testing.T) {
 		}()
 		wg.Wait()
 	}
-
 }
 
 func TestRetryOnError(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes RetryUntilPredicate tests. Updates golang version to v1.19.4

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
fixed RetryUntilPredicate tests.
```
```improvement operator
updated golang version to v1.19.4.
```
