### PR TITLE
removed the call to go tool cover

### DIFF
--- a/.ci/test-unit
+++ b/.ci/test-unit
@@ -44,6 +44,4 @@ fi
 ###############################################################################
 
 make test
-go tool cover -func cover.out
-
 echo "Finished executing unit/env tests."


### PR DESCRIPTION
**What this PR does / why we need it**:
CI/CD pipeline job is currently failing as it tries to look for cover.out file which is no longer produced.

**Which issue(s) this PR fixes**:
Fixes #88 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
