### PR TITLE
switch GCR -> Artifact-Registry 

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 dependency-watchdog:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
@@ -22,7 +20,6 @@ dependency-watchdog:
                 source: ~
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/dependency-watchdog'
             dockerfile: 'Dockerfile'
     steps:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -8,6 +8,8 @@ dependency-watchdog:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -20,7 +22,7 @@ dependency-watchdog:
                 source: ~
               steps:
                 build: ~
-            image: 'eu.gcr.io/gardener-project/gardener/dependency-watchdog'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/dependency-watchdog
             dockerfile: 'Dockerfile'
     steps:
       check:
@@ -33,12 +35,20 @@ dependency-watchdog:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
         draft_release: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
     release:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            dependency-watchdog:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog
         release:
           nextversion: 'bump_minor'
         slack:
@@ -47,4 +57,3 @@ dependency-watchdog:
             internal_scp_workspace:
               channel_name: 'C03D20YPU2K' # gardener-dwd
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERSION             := $(shell cat VERSION)
-REGISTRY            := eu.gcr.io/gardener-project/gardener
+REGISTRY            := europe-docker.pkg.dev/gardener-project/public/gardener
 IMAGE_REPOSITORY    := $(REGISTRY)/dependency-watchdog
 IMAGE_TAG           := $(VERSION)
 BIN_DIR             := bin

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ check-vulnerabilities: $(GO_VULN_CHECK)
 	$(GO_VULN_CHECK) ./...
 
 .PHONY: build
-build: 
+build:
 	@.ci/build
 
 .PHONY: build-local
@@ -36,7 +36,7 @@ build-local:
 	@env LOCAL_BUILD=1 .ci/build
 
 .PHONY: docker-image
-docker-image: 
+docker-image:
 	@docker build -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) -f Dockerfile --rm .
 
 .PHONY: docker-push

--- a/docs/development/setup/dwd-using-local-garden.md
+++ b/docs/development/setup/dwd-using-local-garden.md
@@ -7,7 +7,7 @@ To setup a local garden cluster you can follow the [setup-guide](https://github.
 
 ## Dependency Watchdog resources
 
-As part of the local garden installation, a `local` seed will be available. 
+As part of the local garden installation, a `local` seed will be available.
 
 ### Dependency Watchdog resources created in the seed
 

--- a/docs/development/setup/dwd-using-local-garden.md
+++ b/docs/development/setup/dwd-using-local-garden.md
@@ -60,8 +60,8 @@ Local gardener hosts a docker registry which can be access at `localhost:5001`. 
 ```bash
 > docker images
 # Get the IMAGE ID of the dependency watchdog images that were built using docker-build make target.
-> docker tag <IMAGE-ID> localhost:5001/eu.gcr.io/gardener-project/dependency-watchdog-prober:<TAGNAME>
-> docker push localhost:5001/eu.gcr.io/gardener-project/dependency-watchdog-prober:<TAGNAME>
+> docker tag <IMAGE-ID> localhost:5001/europe-docker.pkg.dev/gardener-project/public/gardener/dependency-watchdog-prober:<TAGNAME>
+> docker push localhost:5001/europe-docker.pkg.dev/gardener-project/public/gardener/dependency-watchdog-prober:<TAGNAME>
 ```
 
 ### Update ManagedResource


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
