### PR TITLE
Use `ginkgolinter` instead of self baked `gomegacheck`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
     - unused
   enable:
     - revive
+    - ginkgolinter
 
 issues:
   exclude-use-default: false

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,13 @@ clean:
 	@rm -rf $(TOOLS_BIN_DIR)
 
 .PHONY: check
-check: $(GOIMPORTS) $(GOLANGCI_LINT) $(GOMEGACHECK) $(LOGCHECK) $(GO_IMPORT_BOSS)
+check: $(GOIMPORTS) $(GOLANGCI_LINT) $(LOGCHECK) $(GO_IMPORT_BOSS)
 	@./hack/check.sh --golangci-lint-config=./.golangci.yaml ./controllers/... ./internal/...
 	@./hack/check-imports.sh ./api/... ./cmd/... ./controllers/... ./internal/...
+
+.PHONY: import-boss 
+import-boss: $(GO_IMPORT_BOSS)
+	@./hack/check-imports.sh ./cmd/...
 
 .PHONY: format
 format:

--- a/controllers/cluster/clusterpredicate_test.go
+++ b/controllers/cluster/clusterpredicate_test.go
@@ -51,7 +51,7 @@ func TestCreateAndDeletePredicateFunc(t *testing.T) {
 
 func testCreatePredicateFunc(g *WithT, numWorkers int) bool {
 	cluster, _, err := test.CreateClusterResource(numWorkers, true)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	e := event.CreateEvent{Object: cluster}
 	predicateFuncs := workerLessShoot(logr.Discard())
 	return predicateFuncs.Create(e)
@@ -59,7 +59,7 @@ func testCreatePredicateFunc(g *WithT, numWorkers int) bool {
 
 func testDeletePredicateFunc(g *WithT, numWorkers int) bool {
 	cluster, _, err := test.CreateClusterResource(numWorkers, true)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	e := event.DeleteEvent{Object: cluster}
 	predicateFuncs := workerLessShoot(logr.Discard())
 	return predicateFuncs.Delete(e)
@@ -90,9 +90,9 @@ func TestUpdatePredicateFunc(t *testing.T) {
 
 func testUpdatePredicateFunc(g *WithT, oldNumWorker, newNumWorkers int) bool {
 	oldCluster, _, err := test.CreateClusterResource(oldNumWorker, true)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	newCluster, _, err := test.CreateClusterResource(newNumWorkers, true)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	e := event.UpdateEvent{
 		ObjectOld: oldCluster,
 		ObjectNew: newCluster,
@@ -122,14 +122,14 @@ func TestShootHasWorkersForNonShootResource(t *testing.T) {
 func TestShootHasWorkersForInvalidShootResource(t *testing.T) {
 	g := NewWithT(t)
 	cluster, _, err := test.CreateClusterResource(0, false)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	seed := gardencorev1beta1.Seed{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "seed-aws",
 		},
 	}
 	seedBytes, err := json.Marshal(seed)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	cluster.Spec.Shoot.Raw = seedBytes
 	result := shootHasWorkers(cluster, logr.Discard())
 	g.Expect(result).To(BeFalse())

--- a/hack/check-imports.sh
+++ b/hack/check-imports.sh
@@ -33,7 +33,7 @@ this_module=$(go list -m)
 export GO111MODULE=off
 
 packages=()
-for p in "$@" ; do
+for p in "$@"; do
   packages+=("$this_module/${p#./}")
 done
 

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -32,11 +32,6 @@ echo "> Check"
 echo "Executing golangci-lint"
 golangci-lint run $GOLANGCI_LINT_CONFIG_FILE --timeout 10m $@
 
-
-echo "Executing gomegacheck"
-# shellcheck disable=SC2068
-gomegacheck ${@:1}
-
 echo "Executing logcheck"
 # shellcheck disable=SC2068
 logcheck ${@:1}

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -5,7 +5,6 @@ TOOLS_BIN_DIR     := $(TOOLS_DIR)/bin
 GOLANGCI_LINT     := $(TOOLS_BIN_DIR)/golangci-lint
 GO_VULN_CHECK     := $(TOOLS_BIN_DIR)/govulncheck
 GOIMPORTS         := $(TOOLS_BIN_DIR)/goimports
-GOMEGACHECK       := $(TOOLS_BIN_DIR)/gomegacheck.so # plugin binary
 LOGCHECK          := $(TOOLS_BIN_DIR)/logcheck.so # plugin binary
 GO_ADD_LICENSE    := $(TOOLS_BIN_DIR)/addlicense
 GO_IMPORT_BOSS    := $(TOOLS_BIN_DIR)/import-boss
@@ -16,10 +15,11 @@ SETUP_ENVTEST     := $(TOOLS_BIN_DIR)/setup-envtest
 GOLANGCI_LINT_VERSION ?= v1.51.2
 GO_VULN_CHECK_VERSION ?= latest
 GOIMPORTS_VERSION ?= latest
-GOMEGACHECK_VERSION ?= latest
 LOGCHECK_VERSION ?= latest
 GO_ADD_LICENSE_VERSION ?= latest
-GO_IMPORT_BOSS_VERSION ?= latest
+# import boss failing with latest , so pinning to most up-to-date successfull version
+# refer https://pkg.go.dev/k8s.io/code-generator@v0.26.3/cmd/import-boss?tab=versions for list of versions
+GO_IMPORT_BOSS_VERSION ?= v0.28.4 
 GO_STRESS_VERSION ?= latest
 SETUP_ENVTEST_VERSION ?= latest
 
@@ -38,8 +38,6 @@ $(GOLANGCI_LINT):
 $(GOIMPORTS):
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
 
-$(GOMEGACHECK):
-	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/gardener/gardener/hack/tools/gomegacheck@$(GOMEGACHECK_VERSION)
 
 $(LOGCHECK):
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/gardener/gardener/hack/tools/logcheck@$(LOGCHECK_VERSION)

--- a/internal/prober/config_test.go
+++ b/internal/prober/config_test.go
@@ -46,8 +46,8 @@ func TestProberConfigSuite(t *testing.T) {
 	}
 
 	scheme := runtime.NewScheme()
-	g.Expect(appsv1.AddToScheme(scheme)).To(BeNil())
-	g.Expect(corev1.AddToScheme(scheme)).To(BeNil())
+	g.Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
 	for _, entry := range tests {
 		t.Run(entry.title, func(t *testing.T) {
@@ -100,7 +100,7 @@ func testMissingConfigValuesShouldReturnErrorAndNilConfig(t *testing.T, s *runti
 		g.Expect(err).To(HaveOccurred(), "LoadConfig should return error for a config with missing mandatory values")
 		g.Expect(config).To(BeNil(), "LoadConfig should return a nil config for a file with missing mandatory values")
 		if merr, ok := err.(*multierr.Error); ok {
-			g.Expect(len(merr.Errors)).To(Equal(entry.expectedErrCount), "LoadConfig did not return all the errors for a faulty config")
+			g.Expect(merr.Errors).To(HaveLen(entry.expectedErrCount), "LoadConfig did not return all the errors for a faulty config")
 		}
 	}
 	t.Log("All the missing mandatory values are identified")
@@ -135,7 +135,7 @@ func testValidConfigShouldPassAllValidations(t *testing.T, s *runtime.Scheme) {
 	config, err := LoadConfig(configPath, s)
 	g.Expect(err).ToNot(HaveOccurred(), "LoadConfig should not give error for a valid config")
 	g.Expect(config).ToNot(BeNil(), "LoadConfig should got nil config for a valid file")
-	g.Expect(len(config.DependentResourceInfos)).To(Equal(3), "LoadConfig did not load all the dependent resources")
+	g.Expect(config.DependentResourceInfos).To(HaveLen(3), "LoadConfig did not load all the dependent resources")
 
 	t.Log("Valid config is loaded correctly")
 }

--- a/internal/prober/probestatus_test.go
+++ b/internal/prober/probestatus_test.go
@@ -75,7 +75,7 @@ func TestRecordSuccess(t *testing.T) {
 
 	g.Expect(ps.successCount).To(Equal(successCount+1), "RecordSuccess should have incremented success count by 1")
 	g.Expect(ps.errorCount).To(BeZero(), "RecordSuccess should have made errorCount equal to 0")
-	g.Expect(ps.lastErr).To(BeNil(), "RecordSuccess should have made lastErr equal to nil")
+	g.Expect(ps.lastErr).ToNot(HaveOccurred(), "RecordSuccess should have made lastErr equal to nil")
 
 	t.Log("RecordSuccess Passed")
 }

--- a/internal/prober/scaler/flow_test.go
+++ b/internal/prober/scaler/flow_test.go
@@ -53,7 +53,7 @@ func TestCreateScaleUpSequentialFlow(t *testing.T) {
 		currentTaskStep := f.flowStepInfos[i]
 		// using taskID format (see createTaskName function) extract and assert level and resource ref targeted in the task step
 		level, resourceRefNames, err := parseTaskID(string(currentTaskStep.taskID))
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(level).To(Equal(i))
 		g.Expect(resourceRefNames).To(HaveLen(1))
 		g.Expect(resourceRefNames[0]).To(Equal(expectedScaleUpResNames[i]))
@@ -87,7 +87,7 @@ func TestCreateScaleDownSequentialAndConcurrentFlow(t *testing.T) {
 		currentTaskStep := f.flowStepInfos[i]
 		// using taskID format (see createTaskName function) extract and assert level and resource ref targeted in the task step
 		level, resourceRefNames, err := parseTaskID(string(currentTaskStep.taskID))
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(level).To(Equal(i))
 		g.Expect(expectedScaleUpResNames[i]).To(Equal(resourceRefNames))
 

--- a/internal/prober/scaler/scaler_test.go
+++ b/internal/prober/scaler/scaler_test.go
@@ -74,7 +74,7 @@ func TestScalerSuite(t *testing.T) {
 			test.run(t)
 		})
 		err := kindTestEnv.DeleteAllDeployments(namespace)
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}
 }
 
@@ -103,19 +103,19 @@ func testScaleDownThenScaleUpWhenIgnoreScalingAnnotationIsNotPresent(t *testing.
 		createDeployment(g, namespace, kcmObjectRef.Name, deploymentImageName, entry.kcmReplicas, nil)
 
 		err := ds.ScaleDown(context.Background())
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 		checkScaleSuccess(g, scaleDown, namespace, caObjectRef.Name, expectedSpecReplicasAfterSuccessfulScaleDownTest)
 		checkScaleSuccess(g, scaleDown, namespace, mcmObjectRef.Name, expectedSpecReplicasAfterSuccessfulScaleDownTest)
 		checkScaleSuccess(g, scaleDown, namespace, kcmObjectRef.Name, expectedSpecReplicasAfterSuccessfulScaleDownTest)
 
 		err = ds.ScaleUp(context.Background())
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 		checkScaleSuccess(g, scaleUp, namespace, mcmObjectRef.Name, entry.expectedScaledUpMCMReplicas)
 		checkScaleSuccess(g, scaleUp, namespace, caObjectRef.Name, entry.expectedScaledUpCAReplicas)
 		checkScaleSuccess(g, scaleUp, namespace, kcmObjectRef.Name, entry.expectedScaledUpKCMReplicas)
 
 		err = kindTestEnv.DeleteAllDeployments(namespace)
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}
 	t.Log("scale down then scale up test finished")
 }
@@ -149,7 +149,7 @@ func testScaleDownThenScaleUpWhenIgnoreScalingAnnotationIsPresent(t *testing.T) 
 		createDeployment(g, namespace, kcmObjectRef.Name, deploymentImageName, entry.kcmReplicas, entry.annotationsOnKCM)
 
 		err := ds.ScaleDown(context.Background())
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 		checkScaleSuccess(g, scaleDown, namespace, caObjectRef.Name, expectedSpecReplicasAfterSuccessfulScaleDownTest)
 		checkScaleSuccess(g, scaleDown, namespace, mcmObjectRef.Name, expectedSpecReplicasAfterSuccessfulScaleDownTest)
 		if reflect.DeepEqual(entry.annotationsOnKCM, validIgnoreScalingAnnotationMap) {
@@ -159,7 +159,7 @@ func testScaleDownThenScaleUpWhenIgnoreScalingAnnotationIsPresent(t *testing.T) 
 		}
 
 		err = ds.ScaleUp(context.Background())
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 		checkScaleSuccess(g, scaleUp, namespace, mcmObjectRef.Name, entry.expectedScaledUpMCMReplicas)
 		checkScaleSuccess(g, scaleUp, namespace, caObjectRef.Name, entry.expectedScaledUpCAReplicas)
 		if reflect.DeepEqual(entry.annotationsOnKCM, validIgnoreScalingAnnotationMap) {
@@ -169,7 +169,7 @@ func testScaleDownThenScaleUpWhenIgnoreScalingAnnotationIsPresent(t *testing.T) 
 		}
 
 		err = kindTestEnv.DeleteAllDeployments(namespace)
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}
 	t.Log("scale down then scale up when ignore scaling annotation is present test finished")
 }
@@ -202,7 +202,7 @@ func testScalingWhenMandatoryResourceNotFound(t *testing.T) {
 		checkScaleSuccess(g, entry.op, namespace, entry.scaledResourceName, entry.expectedScaledResourceSpecReplicas)
 
 		err = kindTestEnv.DeleteAllDeployments(namespace)
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}
 	t.Log("scaling when mandatory resource not found test finished")
 }
@@ -227,12 +227,12 @@ func testScalingWhenOptionalResourceNotFound(t *testing.T) {
 		createDeployment(g, namespace, kcmObjectRef.Name, deploymentImageName, entry.kcmReplicas, nil)
 
 		err := entry.scalingFn(context.Background())
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 		checkScaleSuccess(g, entry.op, namespace, mcmObjectRef.Name, entry.expectedScaledMCMReplicas)
 		checkScaleSuccess(g, entry.op, namespace, kcmObjectRef.Name, entry.expectedScaledCAReplicas)
 
 		err = kindTestEnv.DeleteAllDeployments(namespace)
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}
 	t.Log("scaling when optional resource not found test finished")
 }
@@ -270,7 +270,7 @@ func testGettingScaleSubResourceTimesOut(t *testing.T) {
 		matchSpecReplicas(g, namespace, mcmObjectRef.Name, entry.expectedScaledMCMReplicas)
 
 		err = kindTestEnv.DeleteAllDeployments(namespace)
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}
 	t.Log("updateResourceAndScale times out test finished")
 }
@@ -311,7 +311,7 @@ func testScalingWhenKindOfResourceIsInvalid(t *testing.T) {
 		}
 
 		err = kindTestEnv.DeleteAllDeployments(namespace)
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}
 	t.Log("scaling when res has invalid kind test finished")
 }
@@ -350,7 +350,7 @@ func testScalingWhenKindOfResourceIsInvalid(t *testing.T) {
 //		matchSpecReplicas(g, namespace, mcmObjectRef.Name, entry.expectedScaledMCMReplicas)
 //
 //		err = kindTestEnv.DeleteAllDeployments(namespace)
-//		g.Expect(err).To(BeNil())
+//		g.Expect(err).ToNot(HaveOccurred())
 //	}
 //	t.Log("WaitTillMinTargetReplicasReached returns error test finished")
 //}
@@ -364,13 +364,13 @@ func testResourceShouldNotScaleUpIfCurrentReplicaCountIsPositive(t *testing.T) {
 	createDeployment(g, namespace, kcmObjectRef.Name, deploymentImageName, 1, map[string]string{replicasAnnotationKey: "2"})
 
 	err := ds.ScaleUp(context.Background())
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	checkScaleSuccess(g, scaleUp, namespace, caObjectRef.Name, 1)
 	checkScaleSuccess(g, scaleUp, namespace, kcmObjectRef.Name, 1)
 	matchSpecReplicas(g, namespace, mcmObjectRef.Name, 1)
 
 	err = kindTestEnv.DeleteAllDeployments(namespace)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	t.Log("Resource should not scale up if current replica count is positive test finished")
 }
 
@@ -389,7 +389,7 @@ func testScaleUpShouldReturnErrorWhenReplicasAnnotationsHasInvalidValue(t *testi
 	matchSpecReplicas(g, namespace, mcmObjectRef.Name, 0)
 
 	err = kindTestEnv.DeleteAllDeployments(namespace)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	t.Log("Res should not scale up if replica annotation is incorrect test finished")
 }
 
@@ -399,10 +399,10 @@ func testScaleUpShouldReturnErrorWhenReplicasAnnotationsHasInvalidValue(t *testi
 func setUpScalerTests(g *WithT) func(g *WithT) {
 	var err error
 	kindTestEnv, err = kind.CreateKindCluster(kind.KindConfig{Name: "scaler-test"})
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	return func(g *WithT) {
 		err := kindTestEnv.Delete()
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}
 }
 
@@ -413,7 +413,7 @@ func createDefaultScaler(g *WithT, probeCfg *papi.Config) Scaler {
 func createScaler(g *WithT, probeCfg *papi.Config, resCheckTimeout time.Duration, resCheckInterval time.Duration, scaleResBackoff time.Duration) Scaler {
 	cfg := kindTestEnv.GetRestConfig()
 	scalesGetter, err := util.CreateScalesGetter(cfg)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	ds := NewScaler(namespace, probeCfg, kindTestEnv.GetClient(), scalesGetter, scalerTestLogger,
 		withResourceCheckTimeout(resCheckTimeout), withResourceCheckInterval(resCheckInterval), withScaleResourceBackOff(scaleResBackoff))
 	return ds
@@ -421,7 +421,7 @@ func createScaler(g *WithT, probeCfg *papi.Config, resCheckTimeout time.Duration
 
 func createDeployment(g *WithT, namespace, name, deploymentImageName string, replicas int32, annotations map[string]string) {
 	err := kindTestEnv.CreateDeployment(name, namespace, deploymentImageName, replicas, annotations)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Eventually(func() bool { return checkIfDeploymentReady(namespace, name, replicas) }, 1*time.Minute, time.Second).Should(BeTrue())
 }
 
@@ -449,7 +449,7 @@ func checkScaleSuccess(g *WithT, opType operation, namespace, name string, expec
 
 func matchSpecReplicas(g *WithT, namespace string, name string, expectedReplicas int32) *v1.Deployment {
 	deploy, err := kindTestEnv.GetDeployment(namespace, name)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(deploy).ToNot(BeNil())
 	g.Expect(*deploy.Spec.Replicas).Should(Equal(expectedReplicas))
 	return deploy

--- a/internal/prober/shootclient_test.go
+++ b/internal/prober/shootclient_test.go
@@ -58,7 +58,7 @@ func TestSuite(t *testing.T) {
 		{"testCreateShootClient", "shootclient should be created", testCreateShootClient},
 	}
 	envTest, err = testenv.CreateDefaultControllerTestEnv(scheme.Scheme, nil)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	sk8sClient = envTest.GetClient()
 	for _, test := range tests {
 		ns := testenv.CreateTestNamespace(context.Background(), g, sk8sClient, strings.ToLower(test.name))
@@ -74,7 +74,7 @@ func testSecretNotFound(t *testing.T, namespace string) {
 	setupShootClientTest(t, namespace)
 	k8sInterface, err := clientCreator.CreateClient(sctx, shootClientTestLogger, secret.ObjectMeta.Namespace, secret.ObjectMeta.Name, time.Second)
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-	g.Expect(k8sInterface).To(BeNil())
+	g.Expect(k8sInterface).ToNot(HaveOccurred())
 }
 
 func testConfigNotFound(t *testing.T, namespace string) {
@@ -82,11 +82,11 @@ func testConfigNotFound(t *testing.T, namespace string) {
 	teardown := setupShootClientTest(t, namespace)
 	defer teardown()
 	err := sk8sClient.Create(sctx, secret)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	shootClient, err := clientCreator.CreateClient(sctx, shootClientTestLogger, secret.ObjectMeta.Namespace, secret.ObjectMeta.Name, time.Second)
-	g.Expect(err).ToNot(BeNil())
+	g.Expect(err).To(HaveOccurred())
 	g.Expect(apierrors.IsNotFound(err)).To(BeFalse())
-	g.Expect(shootClient).To(BeNil())
+	g.Expect(shootClient).ToNot(HaveOccurred())
 
 }
 
@@ -95,16 +95,16 @@ func testCreateShootClient(t *testing.T, namespace string) {
 	teardown := setupShootClientTest(t, namespace)
 	defer teardown()
 	kubeconfig, err := testenv.ReadFile(kubeConfigPath)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(kubeconfig).ToNot(BeNil())
 	secret.Data = map[string][]byte{
 		"kubeconfig": kubeconfig.Bytes(),
 	}
 	err = sk8sClient.Create(sctx, secret)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 
 	shootClient, err := clientCreator.CreateClient(sctx, shootClientTestLogger, secret.ObjectMeta.Namespace, secret.ObjectMeta.Name, time.Second)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(shootClient).ToNot(BeNil())
 }
 
@@ -114,12 +114,12 @@ func setupShootClientTest(t *testing.T, namespace string) func() {
 	testenv.FileExistsOrFail(secretPath)
 	secret, err = testenv.GetStructured[corev1.Secret](secretPath)
 	secret.ObjectMeta.Namespace = namespace
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(secret).ToNot(BeNil())
 	clientCreator = NewShootClientCreator(sk8sClient)
 
 	return func() {
 		err := sk8sClient.Delete(sctx, secret)
-		g.Expect(err).Should(BeNil())
+		g.Expect(err).ShouldNot(HaveOccurred())
 	}
 }

--- a/internal/test/util.go
+++ b/internal/test/util.go
@@ -114,7 +114,7 @@ func CreateTestNamespace(ctx context.Context, g *WithT, cli client.Client, nameP
 			GenerateName: namePrefix + "-",
 		},
 	}
-	g.Expect(cli.Create(ctx, &ns)).To(BeNil())
+	g.Expect(cli.Create(ctx, &ns)).To(Succeed())
 	return ns.Name
 }
 

--- a/internal/util/k8shelper_test.go
+++ b/internal/util/k8shelper_test.go
@@ -309,7 +309,7 @@ func testGetResourceAnnotationsWhenNoneExists(t *testing.T) {
 		APIVersion: "apps/v1",
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(annotations).ToNot(HaveOccurred())
+	g.Expect(annotations).To(BeNil())
 }
 
 func testPatchResourceAnnotations(t *testing.T) {

--- a/internal/util/k8shelper_test.go
+++ b/internal/util/k8shelper_test.go
@@ -64,7 +64,7 @@ func beforeAll(t *testing.T) {
 
 	t.Log("setting up kind cluster", "name:", kindTestClusterName)
 	kindCluster, err = testutil.CreateKindCluster(testutil.KindConfig{Name: kindTestClusterName})
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	k8sClient = kindCluster.GetClient()
 	restConfig = kindCluster.GetRestConfig()
 }
@@ -73,7 +73,7 @@ func afterAll(t *testing.T) {
 	g := NewWithT(t)
 	t.Log("deleting kind cluster", "name:", kindTestClusterName)
 	err := kindCluster.Delete()
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 }
 
 func TestSuitForK8sHelper(t *testing.T) {
@@ -164,7 +164,7 @@ func testCreateScalesGetter(t *testing.T) {
 	config := getRestConfig(g, kubeConfigPath)
 
 	scalesGetter, err := CreateScalesGetter(config)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(scalesGetter).ToNot(BeNil())
 }
 
@@ -176,7 +176,7 @@ func testGetScaleResource(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 	scalesGetter, err := CreateScalesGetter(restConfig)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(scalesGetter).ToNot(BeNil())
 
 	deployment, cleanup := createDeployment(ctx, g, deploymentPath)
@@ -190,7 +190,7 @@ func testGetScaleResource(t *testing.T) {
 
 	scaler := scalesGetter.Scales(deployment.Namespace)
 	groupResource, scaleRes, err := GetScaleResource(ctx, k8sClient, scaler, k8sHelperTestLogger, resourceRef, 20*time.Second)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(groupResource.Group).To(Equal(resourceGroup))
 	g.Expect(groupResource.Resource).To(Equal(deploymentResource))
@@ -202,7 +202,7 @@ func testGetScaleResourceForUnsupportedGKV(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 	scalesGetter, err := CreateScalesGetter(restConfig)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(scalesGetter).ToNot(BeNil())
 
 	resourceRef := &autoscalingv1.CrossVersionObjectReference{
@@ -244,7 +244,7 @@ func testGetReadyReplicasForResourceWithZeroReplicas(t *testing.T) {
 	}
 
 	readyReplicas, err := GetResourceReadyReplicas(ctx, k8sClient, namespace, resourceRef)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(readyReplicas).To(Equal(int32(0)))
 }
 
@@ -260,7 +260,7 @@ func testGetReadyReplicasForResourceWithNonZeroReplicas(t *testing.T) {
 	defer cleanup(g)
 	d.Spec.Replicas = pointer.Int32(1)
 	err = k8sClient.Create(ctx, d)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Eventually(func() int32 {
 		replicas, err = GetResourceReadyReplicas(ctx, k8sClient, namespace, &autoscalingv1.CrossVersionObjectReference{
@@ -268,7 +268,7 @@ func testGetReadyReplicasForResourceWithNonZeroReplicas(t *testing.T) {
 			Name:       d.Name,
 			APIVersion: "apps/v1",
 		})
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 		return replicas
 	}, "30s").Should(Equal(int32(1)))
 }
@@ -282,14 +282,14 @@ func testGetResourceAnnotations(t *testing.T) {
 	defer cleanup(g)
 	metav1.SetMetaDataAnnotation(&d.ObjectMeta, "test.gardener.cloud/bingo", "tringo")
 	err = k8sClient.Create(ctx, d)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 
 	annotations, err := GetResourceAnnotations(ctx, k8sClient, namespace, &autoscalingv1.CrossVersionObjectReference{
 		Kind:       "Deployment",
 		Name:       d.Name,
 		APIVersion: "apps/v1",
 	})
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(annotations).Should(HaveKeyWithValue("test.gardener.cloud/bingo", "tringo"))
 }
 
@@ -301,15 +301,15 @@ func testGetResourceAnnotationsWhenNoneExists(t *testing.T) {
 	d, cleanup := getDeploymentFromFile(ctx, g, deploymentPath)
 	defer cleanup(g)
 	err = k8sClient.Create(ctx, d)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 
 	annotations, err := GetResourceAnnotations(ctx, k8sClient, namespace, &autoscalingv1.CrossVersionObjectReference{
 		Kind:       "Deployment",
 		Name:       d.Name,
 		APIVersion: "apps/v1",
 	})
-	g.Expect(err).To(BeNil())
-	g.Expect(annotations).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(annotations).ToNot(HaveOccurred())
 }
 
 func testPatchResourceAnnotations(t *testing.T) {
@@ -332,9 +332,9 @@ func testPatchResourceAnnotations(t *testing.T) {
 
 	patchBytes := createAnnotationPatchBytes(g, expectedAnnotations)
 	err := PatchResourceAnnotations(ctx, k8sClient, namespace, resourceRef, patchBytes)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	actualAnnotation, err := GetResourceAnnotations(ctx, k8sClient, namespace, resourceRef)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	for k, v := range expectedAnnotations {
 		g.Expect(actualAnnotation).To(HaveKeyWithValue(k, v))
 	}
@@ -342,7 +342,7 @@ func testPatchResourceAnnotations(t *testing.T) {
 
 func createAnnotationPatchBytes(g *WithT, annotMap map[string]string) []byte {
 	mapJson, err := json.Marshal(annotMap)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	b := strings.Builder{}
 	b.WriteString("{\"metadata\":{\"annotations\":")
 	b.WriteString(string(mapJson))
@@ -352,7 +352,7 @@ func createAnnotationPatchBytes(g *WithT, annotMap map[string]string) []byte {
 
 func getSecretFromFile(ctx context.Context, g *WithT) (*corev1.Secret, testCleanup) {
 	secret, err := testutil.GetStructured[corev1.Secret](secretPath)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(secret).ShouldNot(BeNil())
 	return secret, func(g *WithT) {
 		err := client.IgnoreNotFound(k8sClient.Delete(ctx, secret))
@@ -376,10 +376,10 @@ func createKubeConfigSecret(ctx context.Context, g *WithT, sec *corev1.Secret, k
 func createDeployment(ctx context.Context, g *WithT, yamlPath string) (*appsv1.Deployment, testCleanup) {
 	d, cleanup := getDeploymentFromFile(ctx, g, yamlPath)
 	err := k8sClient.Create(ctx, d)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	// post create TypeMeta is blanked out @see https://github.com/kubernetes-sigs/controller-runtime/issues/1517
 	gvks, unversioned, err := k8sClient.Scheme().ObjectKinds(d)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	if !unversioned && len(gvks) == 1 {
 		d.SetGroupVersionKind(gvks[0])
 	}
@@ -388,11 +388,11 @@ func createDeployment(ctx context.Context, g *WithT, yamlPath string) (*appsv1.D
 
 func getDeploymentFromFile(ctx context.Context, g *WithT, yamlPath string) (*appsv1.Deployment, testCleanup) {
 	d, err := testutil.GetStructured[appsv1.Deployment](yamlPath)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(d).ShouldNot(BeNil())
 	return d, func(g *WithT) {
 		err := client.IgnoreNotFound(k8sClient.Delete(ctx, d))
-		g.Expect(err).To(BeNil())
+		g.Expect(err).ToNot(HaveOccurred())
 	}
 }
 

--- a/internal/util/retry_test.go
+++ b/internal/util/retry_test.go
@@ -40,9 +40,9 @@ var (
 func TestNoErrorIfTaskEventuallySucceeds(t *testing.T) {
 	g := NewWithT(t)
 	result := Retry(context.Background(), retryTestLogger, "", passEventually(), numAttempts, backoff, AlwaysRetry)
-	g.Expect(result.Err).Should(BeNil())
+	g.Expect(result.Err).ShouldNot(HaveOccurred())
 	g.Expect(result.Value).Should(Equal("appendPass"))
-	g.Expect(len(list)).Should(Equal(3))
+	g.Expect(list).Should(HaveLen(3))
 	g.Expect(list[0:2]).Should(ConsistOf("appendFail", "appendFail"))
 	g.Expect(list[2]).To(Equal("appendPass"))
 	emptyList()
@@ -51,7 +51,7 @@ func TestNoErrorIfTaskEventuallySucceeds(t *testing.T) {
 func TestErrorIfExceedsAttempts(t *testing.T) {
 	g := NewWithT(t)
 	result := Retry(context.Background(), retryTestLogger, "", appendFail, numAttempts, backoff, AlwaysRetry)
-	g.Expect(len(list)).Should(Equal(numAttempts))
+	g.Expect(list).Should(HaveLen(numAttempts))
 	g.Expect(result.Err.Error()).Should(Equal("appendFail"))
 	g.Expect(result.Value).Should(Equal("appendFail"))
 	emptyList()
@@ -68,7 +68,7 @@ func TestCanRetryReturnsFalse(t *testing.T) {
 		return false
 	}
 	result := Retry(context.Background(), retryTestLogger, "", passEventually(), numAttempts, backoff, runOnceFn)
-	g.Expect(len(list)).Should(Equal(2))
+	g.Expect(list).Should(HaveLen(2))
 	g.Expect(list[0:2]).Should(ConsistOf("appendFail", "appendFail"))
 	g.Expect(result.Err.Error()).Should(Equal("appendFail"))
 	g.Expect(result.Value).Should(Equal(""))
@@ -110,7 +110,7 @@ func TestContextCancelledBeforeBackoffBegins(t *testing.T) {
 
 		g.Expect(result.Err).Should(Equal(context.Canceled))
 		g.Expect(result.Value).Should(Equal(""))
-		g.Expect(len(list)).Should(Equal(1))
+		g.Expect(list).Should(HaveLen(1))
 	}()
 	wg.Wait()
 	emptyList()
@@ -183,7 +183,7 @@ func TestRetryOnErrorWhenContextIsCancelled(t *testing.T) {
 	time.Sleep(20 * time.Millisecond) //forcing counter to be incremented
 	cancelFn()
 	g.Expect(counter).To(BeNumerically(">", 0))
-	g.Expect(ctx.Err()).ToNot(BeNil())
+	g.Expect(ctx.Err()).ToNot(Succeed())
 }
 
 func appendFail() (string, error) {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -32,7 +32,7 @@ func TestSleepWithContextShouldStopIfDeadlineExceeded(t *testing.T) {
 	ctx, cancelFn := context.WithTimeout(context.Background(), 2*time.Millisecond)
 	defer cancelFn()
 	err := SleepWithContext(ctx, 10*time.Millisecond)
-	g.Expect(err).ShouldNot(BeNil())
+	g.Expect(err).Should(HaveOccurred())
 	g.Expect(err).Should(Equal(context.DeadlineExceeded))
 }
 
@@ -55,13 +55,13 @@ func TestSleepWithContextForNonCancellableContext(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 	err := SleepWithContext(ctx, time.Microsecond)
-	g.Expect(err).Should(BeNil())
+	g.Expect(err).ShouldNot(HaveOccurred())
 }
 
 func TestReadAndUnmarshallNonExistingFile(t *testing.T) {
 	g := NewWithT(t)
 	_, err := ReadAndUnmarshall[papi.Config]("file-that-does-not-exists.yaml")
-	g.Expect(err).ToNot(BeNil())
+	g.Expect(err).To(HaveOccurred())
 }
 
 func TestReadAndUnmarshall(t *testing.T) {
@@ -73,7 +73,7 @@ func TestReadAndUnmarshall(t *testing.T) {
 	}
 	configPath := filepath.Join("testdata", "test-config.yaml")
 	c, err := ReadAndUnmarshall[config](configPath)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(c.Name).To(Equal("zeus"))
 	g.Expect(c.Version).To(Equal("v1.0"))
 	expectedData := map[string]string{"level": "god-like", "type": "warrior"}

--- a/internal/util/validator_test.go
+++ b/internal/util/validator_test.go
@@ -48,7 +48,7 @@ func TestMustNotBeEmpty(t *testing.T) {
 		actualResult := v.MustNotBeEmpty(entry.key, entry.value)
 		g.Expect(entry.result).To(Equal(actualResult))
 		if !actualResult {
-			g.Expect(v.Error).ToNot(BeNil())
+			g.Expect(v.Error).To(HaveOccurred())
 		}
 	}
 }
@@ -71,7 +71,7 @@ func TestMustNotBeNil(t *testing.T) {
 		actualResult := v.MustNotBeNil(entry.key, entry.value)
 		g.Expect(entry.result).To(Equal(actualResult))
 		if !actualResult {
-			g.Expect(v.Error).ToNot(BeNil())
+			g.Expect(v.Error).To(HaveOccurred())
 		}
 	}
 }
@@ -80,8 +80,8 @@ func TestResourceRefMustBeValid(t *testing.T) {
 	g := NewWithT(t)
 
 	scheme := runtime.NewScheme()
-	g.Expect(appsv1.AddToScheme(scheme)).To(BeNil())
-	g.Expect(corev1.AddToScheme(scheme)).To(BeNil())
+	g.Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
 	tests := []struct {
 		resourceRef autoscalingv1.CrossVersionObjectReference

--- a/internal/weeder/config_test.go
+++ b/internal/weeder/config_test.go
@@ -33,7 +33,7 @@ func TestConfigFileNotFound(t *testing.T) {
 	g := NewWithT(t)
 	config, err := LoadConfig(filepath.Join(testdataPath, "notfound.yaml"))
 	g.Expect(err).To(HaveOccurred(), "LoadConfig should give error if config file is not found")
-	g.Expect(config).ToNot(HaveOccurred(), "LoadConfig should return a nil config if config file is not found")
+	g.Expect(config).To(BeNil(), "LoadConfig should return a nil config if config file is not found")
 	g.Expect(err.Error()).To(ContainSubstring("no such file or directory"), "LoadConfig did not load all the dependent resources")
 }
 
@@ -68,7 +68,7 @@ func TestMissingMandatoryFieldsShouldReturnErrorAndNilConfig(t *testing.T) {
 		config, err := LoadConfig(configPath)
 
 		g.Expect(err).To(HaveOccurred(), "LoadConfig should return error for a config with missing mandatory values")
-		g.Expect(config).ToNot(HaveOccurred(), "LoadConfig should return a nil config for a file with missing mandatory values")
+		g.Expect(config).To(BeNil(), "LoadConfig should return a nil config for a file with missing mandatory values")
 		if merr, ok := err.(*multierr.Error); ok {
 			g.Expect(merr.Errors).To(HaveLen(entry.expectedErrCount), "LoadConfig did not return all the errors for a faulty config")
 		}

--- a/internal/weeder/config_test.go
+++ b/internal/weeder/config_test.go
@@ -33,7 +33,7 @@ func TestConfigFileNotFound(t *testing.T) {
 	g := NewWithT(t)
 	config, err := LoadConfig(filepath.Join(testdataPath, "notfound.yaml"))
 	g.Expect(err).To(HaveOccurred(), "LoadConfig should give error if config file is not found")
-	g.Expect(config).To(BeNil(), "LoadConfig should return a nil config if config file is not found")
+	g.Expect(config).ToNot(HaveOccurred(), "LoadConfig should return a nil config if config file is not found")
 	g.Expect(err.Error()).To(ContainSubstring("no such file or directory"), "LoadConfig did not load all the dependent resources")
 }
 
@@ -68,9 +68,9 @@ func TestMissingMandatoryFieldsShouldReturnErrorAndNilConfig(t *testing.T) {
 		config, err := LoadConfig(configPath)
 
 		g.Expect(err).To(HaveOccurred(), "LoadConfig should return error for a config with missing mandatory values")
-		g.Expect(config).To(BeNil(), "LoadConfig should return a nil config for a file with missing mandatory values")
+		g.Expect(config).ToNot(HaveOccurred(), "LoadConfig should return a nil config for a file with missing mandatory values")
 		if merr, ok := err.(*multierr.Error); ok {
-			g.Expect(len(merr.Errors)).To(Equal(entry.expectedErrCount), "LoadConfig did not return all the errors for a faulty config")
+			g.Expect(merr.Errors).To(HaveLen(entry.expectedErrCount), "LoadConfig did not return all the errors for a faulty config")
 		}
 	}
 	t.Log("All the missing mandatory values are identified")
@@ -85,7 +85,7 @@ func TestValidConfigShouldPassAllValidations(t *testing.T) {
 	config, err := LoadConfig(configPath)
 	g.Expect(err).ToNot(HaveOccurred(), "LoadConfig should not give error for a valid config")
 	g.Expect(config).ToNot(BeNil(), "LoadConfig should got nil config for a valid file")
-	g.Expect(len(config.ServicesAndDependantSelectors)).To(Equal(2), "LoadConfig did not load all the dependent resources")
+	g.Expect(config.ServicesAndDependantSelectors).To(HaveLen(2), "LoadConfig did not load all the dependent resources")
 
 	t.Log("Valid config is loaded correctly")
 }


### PR DESCRIPTION
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Switch from own gomegacheck linter to use an officially supported golangci-lint linter for ginkgo/gomega checks.

Additionally the linting erros in the tests have been fixed.

refer https://github.com/gardener/gardener/pull/8769

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Use `ginkgolinter` instead of self baked `gomegacheck`
```
