### PR TITLE
Make `kcmNodeMonitorGraceDuration` optional in the config

### DIFF
--- a/api/prober/types.go
+++ b/api/prober/types.go
@@ -34,9 +34,6 @@ type Config struct {
 	// DependentResourceInfos are the dependent resources that should be considered for scaling in case the shoot control API server cannot be reached via external domain
 	DependentResourceInfos []DependentResourceInfo `json:"dependentResourceInfos"`
 	// KCMNodeMonitorGraceDuration is the node-monitor-grace-period set in the kcm flags.
-	// If this field is not specified in the dwd-config, the default value is picked as follows:-
-	// 1. For shoot with k8s version < 1.27, default value of 120s is used.
-	// 2. For shoot with k8s version >= 1.27, default value of 40s is used.
 	KCMNodeMonitorGraceDuration *metav1.Duration `json:"kcmNodeMonitorGraceDuration,omitempty"`
 	// NodeLeaseFailureFraction is used to determine the maximum number of leases that can be expired for a lease probe to succeed.
 	NodeLeaseFailureFraction *float64 `json:"nodeLeaseFailureFraction,omitempty"`

--- a/api/prober/types.go
+++ b/api/prober/types.go
@@ -33,8 +33,11 @@ type Config struct {
 	BackoffJitterFactor *float64 `json:"backoffJitterFactor,omitempty"`
 	// DependentResourceInfos are the dependent resources that should be considered for scaling in case the shoot control API server cannot be reached via external domain
 	DependentResourceInfos []DependentResourceInfo `json:"dependentResourceInfos"`
-	// KCMNodeMonitorGraceDuration is the node-monitor-grace-period set in the kcm flags
-	KCMNodeMonitorGraceDuration metav1.Duration `json:"kcmNodeMonitorGraceDuration"`
+	// KCMNodeMonitorGraceDuration is the node-monitor-grace-period set in the kcm flags.
+	// If this field is not specified in the dwd-config, the default value is picked as follows:-
+	// 1. For shoot with k8s version < 1.27, default value of 120s is used.
+	// 2. For shoot with k8s version >= 1.27, default value of 40s is used.
+	KCMNodeMonitorGraceDuration *metav1.Duration `json:"kcmNodeMonitorGraceDuration,omitempty"`
 	// NodeLeaseFailureFraction is used to determine the maximum number of leases that can be expired for a lease probe to succeed.
 	NodeLeaseFailureFraction *float64 `json:"nodeLeaseFailureFraction,omitempty"`
 }

--- a/controllers/cluster/cluster_controller.go
+++ b/controllers/cluster/cluster_controller.go
@@ -215,7 +215,7 @@ func (r *Reconciler) getEffectiveProbeConfig(shoot *v1beta1.Shoot, logger logr.L
 	} else {
 		k8sVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
 		if err != nil {
-			logger.Error(err, "Failed to determine parse shoot k8s version, cannot create probe")
+			logger.Error(err, "Failed to parse shoot k8s version, cannot create probe")
 			return nil, err
 		}
 		if version.ConstraintK8sGreaterEqual127.Check(k8sVersion) {

--- a/controllers/cluster/cluster_controller.go
+++ b/controllers/cluster/cluster_controller.go
@@ -19,11 +19,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"time"
-
-	"github.com/Masterminds/semver/v3"
-	"github.com/gardener/gardener/pkg/utils/version"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	papi "github.com/gardener/dependency-watchdog/api/prober"
 	"github.com/gardener/dependency-watchdog/internal/prober/scaler"
@@ -48,11 +43,6 @@ import (
 )
 
 const controllerName = "cluster"
-
-var (
-	defaultKCMNodeMonitorGraceDurationForK8sGreaterEqual127 = metav1.Duration{Duration: 40 * time.Second}
-	defaultKCMNodeMonitorGraceDurationForK8sLesserThan127   = metav1.Duration{Duration: 120 * time.Second}
-)
 
 // Reconciler reconciles a Cluster object
 type Reconciler struct {
@@ -131,10 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if canStartProber(shoot) {
-		err = r.startProber(ctx, shoot, log, req.Name)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+		r.startProber(ctx, shoot, log, req.Name)
 	}
 	return ctrl.Result{}, nil
 }
@@ -172,13 +159,10 @@ func canStartProber(shoot *v1beta1.Shoot) bool {
 
 // startProber sets up a new probe against a given key which uniquely identifies the probe.
 // Typically, the key in case of a shoot cluster is the shoot namespace
-func (r *Reconciler) startProber(ctx context.Context, shoot *v1beta1.Shoot, logger logr.Logger, key string) error {
+func (r *Reconciler) startProber(ctx context.Context, shoot *v1beta1.Shoot, logger logr.Logger, key string) {
 	_, ok := r.ProberMgr.GetProber(key)
 	if !ok {
-		probeConfig, err := r.getEffectiveProbeConfig(shoot, logger)
-		if err != nil {
-			return err
-		}
+		probeConfig := r.getEffectiveProbeConfig(shoot, logger)
 		deploymentScaler := scaler.NewScaler(key, probeConfig.DependentResourceInfos, r.Client, r.ScaleGetter, logger)
 		shootClientCreator := prober.NewShootClientCreator(r.Client)
 		p := prober.NewProber(ctx, key, probeConfig, deploymentScaler, shootClientCreator, logger)
@@ -186,7 +170,6 @@ func (r *Reconciler) startProber(ctx context.Context, shoot *v1beta1.Shoot, logg
 		logger.Info("Starting a new prober")
 		go p.Run()
 	}
-	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -206,23 +189,12 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // getEffectiveProbeConfig returns the updated probe config after checking the shoot KCM configuration for NodeMonitorGracePeriod.
 // If NodeMonitorGracePeriod is not set in the shoot, then the KCMNodeMonitorGraceDuration defined in the configmap of probe config will be used
-func (r *Reconciler) getEffectiveProbeConfig(shoot *v1beta1.Shoot, logger logr.Logger) (*papi.Config, error) {
+func (r *Reconciler) getEffectiveProbeConfig(shoot *v1beta1.Shoot, logger logr.Logger) *papi.Config {
 	probeConfig := *r.DefaultProbeConfig
 	kcmConfig := shoot.Spec.Kubernetes.KubeControllerManager
 	if kcmConfig != nil && kcmConfig.NodeMonitorGracePeriod != nil {
 		logger.Info("Using the NodeMonitorGracePeriod set in the shoot as KCMNodeMonitorGraceDuration in the probe config", "nodeMonitorGraceDuration", *kcmConfig.NodeMonitorGracePeriod)
 		probeConfig.KCMNodeMonitorGraceDuration = kcmConfig.NodeMonitorGracePeriod
-	} else {
-		k8sVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
-		if err != nil {
-			logger.Error(err, "Failed to parse shoot k8s version, cannot create probe")
-			return nil, err
-		}
-		if version.ConstraintK8sGreaterEqual127.Check(k8sVersion) {
-			probeConfig.KCMNodeMonitorGraceDuration = &defaultKCMNodeMonitorGraceDurationForK8sGreaterEqual127
-		} else {
-			probeConfig.KCMNodeMonitorGraceDuration = &defaultKCMNodeMonitorGraceDurationForK8sLesserThan127
-		}
 	}
-	return &probeConfig, nil
+	return &probeConfig
 }

--- a/controllers/cluster/cluster_controller_test.go
+++ b/controllers/cluster/cluster_controller_test.go
@@ -52,6 +52,8 @@ import (
 const (
 	testdataPath                  = "testdata"
 	maxConcurrentReconcilesProber = 1
+	k8sVersion126                 = "v1.26.0"
+	k8sVersion127                 = "v1.27.0"
 )
 
 var shootKCMNodeMonitorGracePeriod = &metav1.Duration{Duration: 40 * time.Second}
@@ -144,7 +146,7 @@ func testProberDedicatedEnvTest(t *testing.T) {
 func testReconciliationAfterAPIServerIsDown(ctx context.Context, t *testing.T, testEnv *envtest.Environment, _ client.Client, reconciler *Reconciler, _ manager.Manager, cancelFn context.CancelFunc) {
 	var err error
 	g := NewWithT(t)
-	cluster, _, err := testutil.CreateClusterResource(1, nil, false)
+	cluster, _, err := testutil.CreateClusterResource(1, nil, k8sVersion127, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	cancelFn()
 	err = testEnv.ControlPlane.APIServer.Stop()
@@ -218,10 +220,10 @@ func updateShootHibernationSpec(g *WithT, crClient client.Client, cluster *garde
 }
 
 func testShootHibernation(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion127, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	createCluster(g, crClient, cluster)
-	proberShouldBePresent(g, reconciler, cluster, reconciler.DefaultProbeConfig.KCMNodeMonitorGraceDuration)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sGreaterEqual127)
 	// update spec to indicate start of hibernation
 	updateShootHibernationSpec(g, crClient, cluster, shoot, pointer.Bool(true))
 	proberShouldNotBePresent(g, reconciler, cluster)
@@ -232,7 +234,7 @@ func testShootHibernation(g *WithT, crClient client.Client, reconciler *Reconcil
 	proberShouldNotBePresent(g, reconciler, cluster)
 	// update status to indicate cluster has successfully woken up
 	updateShootHibernationStatus(g, crClient, cluster, shoot, false)
-	proberShouldBePresent(g, reconciler, cluster, reconciler.DefaultProbeConfig.KCMNodeMonitorGraceDuration)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sGreaterEqual127)
 	deleteClusterAndCheckIfProberRemoved(g, crClient, reconciler, cluster)
 }
 
@@ -245,7 +247,7 @@ func updateShootHibernationStatus(g *WithT, crClient client.Client, cluster *gar
 }
 
 func testInvalidShootInClusterSpec(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, _, err := testutil.CreateClusterResource(1, nil, false)
+	cluster, _, err := testutil.CreateClusterResource(1, nil, k8sVersion126, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	cluster.Spec.Shoot.Object = nil
 	cluster.Spec.Shoot.Raw = []byte(`{"apiVersion": 8}`)
@@ -267,10 +269,10 @@ func updateShootDeletionTimeStamp(g *WithT, crClient client.Client, cluster *gar
 }
 
 func testProberShouldBeRemovedIfDeletionTimeStampIsSet(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion126, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	createCluster(g, crClient, cluster)
-	proberShouldBePresent(g, reconciler, cluster, reconciler.DefaultProbeConfig.KCMNodeMonitorGraceDuration)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sLesserThan127)
 	updateShootDeletionTimeStamp(g, crClient, cluster, shoot)
 	proberShouldNotBePresent(g, reconciler, cluster)
 	deleteClusterAndCheckIfProberRemoved(g, crClient, reconciler, cluster)
@@ -299,7 +301,7 @@ func testShootCreationNotComplete(g *WithT, crClient client.Client, reconciler *
 	}
 
 	for _, testCase := range testCases {
-		cluster, shoot, err := testutil.CreateClusterResource(1, shootKCMNodeMonitorGracePeriod, false)
+		cluster, shoot, err := testutil.CreateClusterResource(1, shootKCMNodeMonitorGracePeriod, k8sVersion126, false)
 		g.Expect(err).ToNot(HaveOccurred())
 		setShootLastOperationStatus(cluster, shoot, gardencorev1beta1.LastOperationTypeCreate, testCase.lastOpState)
 		createCluster(g, crClient, cluster)
@@ -313,7 +315,7 @@ func testShootCreationNotComplete(g *WithT, crClient client.Client, reconciler *
 }
 
 func testShootIsMigrating(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion127, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	createCluster(g, crClient, cluster)
 	setShootLastOperationStatus(cluster, shoot, gardencorev1beta1.LastOperationTypeMigrate, "")
@@ -323,10 +325,10 @@ func testShootIsMigrating(g *WithT, crClient client.Client, reconciler *Reconcil
 }
 
 func testShootRestoringIsNotComplete(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion126, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	createCluster(g, crClient, cluster)
-	proberShouldBePresent(g, reconciler, cluster, reconciler.DefaultProbeConfig.KCMNodeMonitorGraceDuration)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sLesserThan127)
 	// cluster migration starts
 	setShootLastOperationStatus(cluster, shoot, gardencorev1beta1.LastOperationTypeMigrate, "")
 	updateCluster(g, crClient, cluster)
@@ -339,25 +341,25 @@ func testShootRestoringIsNotComplete(g *WithT, crClient client.Client, reconcile
 }
 
 func testLastOperationIsRestoreAndSuccessful(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion127, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	setShootLastOperationStatus(cluster, shoot, gardencorev1beta1.LastOperationTypeRestore, gardencorev1beta1.LastOperationStateSucceeded)
 	createCluster(g, crClient, cluster)
-	proberShouldBePresent(g, reconciler, cluster, reconciler.DefaultProbeConfig.KCMNodeMonitorGraceDuration)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sGreaterEqual127)
 	deleteClusterAndCheckIfProberRemoved(g, crClient, reconciler, cluster)
 }
 
 func testLastOperationIsShootReconciliation(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion126, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	setShootLastOperationStatus(cluster, shoot, gardencorev1beta1.LastOperationTypeReconcile, "")
 	createCluster(g, crClient, cluster)
-	proberShouldBePresent(g, reconciler, cluster, reconciler.DefaultProbeConfig.KCMNodeMonitorGraceDuration)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sLesserThan127)
 	deleteClusterAndCheckIfProberRemoved(g, crClient, reconciler, cluster)
 }
 
 func testShootHasNoWorkers(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, _, err := testutil.CreateClusterResource(0, nil, false)
+	cluster, _, err := testutil.CreateClusterResource(0, nil, k8sVersion127, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	createCluster(g, crClient, cluster)
 	proberShouldNotBePresent(g, reconciler, cluster)
@@ -367,7 +369,7 @@ func proberShouldBePresent(g *WithT, reconciler *Reconciler, cluster *gardenerv1
 	g.Eventually(func() int { return len(reconciler.ProberMgr.GetAllProbers()) }, 10*time.Second, 1*time.Second).Should(Equal(1))
 	prober, ok := reconciler.ProberMgr.GetProber(cluster.ObjectMeta.Name)
 	g.Expect(ok).To(BeTrue())
-	g.Expect(prober.GetConfig().KCMNodeMonitorGraceDuration).To(Equal(kcmNodeMonitorGraceDuration))
+	g.Expect(*prober.GetConfig().KCMNodeMonitorGraceDuration).To(Equal(kcmNodeMonitorGraceDuration))
 	g.Expect(prober.IsClosed()).To(BeFalse())
 }
 

--- a/controllers/cluster/cluster_controller_test.go
+++ b/controllers/cluster/cluster_controller_test.go
@@ -365,11 +365,11 @@ func testShootHasNoWorkers(g *WithT, crClient client.Client, reconciler *Reconci
 	proberShouldNotBePresent(g, reconciler, cluster)
 }
 
-func proberShouldBePresent(g *WithT, reconciler *Reconciler, cluster *gardenerv1alpha1.Cluster, kcmNodeMonitorGraceDuration metav1.Duration) {
+func proberShouldBePresent(g *WithT, reconciler *Reconciler, cluster *gardenerv1alpha1.Cluster, expectedKCMNodeMonitorGraceDuration metav1.Duration) {
 	g.Eventually(func() int { return len(reconciler.ProberMgr.GetAllProbers()) }, 10*time.Second, 1*time.Second).Should(Equal(1))
 	prober, ok := reconciler.ProberMgr.GetProber(cluster.ObjectMeta.Name)
 	g.Expect(ok).To(BeTrue())
-	g.Expect(*prober.GetConfig().KCMNodeMonitorGraceDuration).To(Equal(kcmNodeMonitorGraceDuration))
+	g.Expect(*prober.GetConfig().KCMNodeMonitorGraceDuration).To(Equal(expectedKCMNodeMonitorGraceDuration))
 	g.Expect(prober.IsClosed()).To(BeFalse())
 }
 

--- a/controllers/cluster/cluster_controller_test.go
+++ b/controllers/cluster/cluster_controller_test.go
@@ -52,11 +52,12 @@ import (
 const (
 	testdataPath                  = "testdata"
 	maxConcurrentReconcilesProber = 1
-	k8sVersion126                 = "v1.26.0"
-	k8sVersion127                 = "v1.27.0"
 )
 
-var shootKCMNodeMonitorGracePeriod = &metav1.Duration{Duration: 40 * time.Second}
+var (
+	shootKCMNodeMonitorGracePeriod   = &metav1.Duration{Duration: 80 * time.Second}
+	defaultKCMNodeMonitorGracePeriod = metav1.Duration{Duration: proberpackage.DefaultKCMNodeMonitorGraceDuration}
+)
 
 func setupProberEnv(ctx context.Context, g *WithT) (client.Client, *envtest.Environment, *Reconciler, manager.Manager) {
 	scheme := buildScheme()
@@ -146,7 +147,7 @@ func testProberDedicatedEnvTest(t *testing.T) {
 func testReconciliationAfterAPIServerIsDown(ctx context.Context, t *testing.T, testEnv *envtest.Environment, _ client.Client, reconciler *Reconciler, _ manager.Manager, cancelFn context.CancelFunc) {
 	var err error
 	g := NewWithT(t)
-	cluster, _, err := testutil.CreateClusterResource(1, nil, k8sVersion127, false)
+	cluster, _, err := testutil.CreateClusterResource(1, nil, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	cancelFn()
 	err = testEnv.ControlPlane.APIServer.Stop()
@@ -220,10 +221,10 @@ func updateShootHibernationSpec(g *WithT, crClient client.Client, cluster *garde
 }
 
 func testShootHibernation(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion127, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	createCluster(g, crClient, cluster)
-	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sGreaterEqual127)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGracePeriod)
 	// update spec to indicate start of hibernation
 	updateShootHibernationSpec(g, crClient, cluster, shoot, pointer.Bool(true))
 	proberShouldNotBePresent(g, reconciler, cluster)
@@ -234,7 +235,7 @@ func testShootHibernation(g *WithT, crClient client.Client, reconciler *Reconcil
 	proberShouldNotBePresent(g, reconciler, cluster)
 	// update status to indicate cluster has successfully woken up
 	updateShootHibernationStatus(g, crClient, cluster, shoot, false)
-	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sGreaterEqual127)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGracePeriod)
 	deleteClusterAndCheckIfProberRemoved(g, crClient, reconciler, cluster)
 }
 
@@ -247,7 +248,7 @@ func updateShootHibernationStatus(g *WithT, crClient client.Client, cluster *gar
 }
 
 func testInvalidShootInClusterSpec(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, _, err := testutil.CreateClusterResource(1, nil, k8sVersion126, false)
+	cluster, _, err := testutil.CreateClusterResource(1, nil, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	cluster.Spec.Shoot.Object = nil
 	cluster.Spec.Shoot.Raw = []byte(`{"apiVersion": 8}`)
@@ -269,10 +270,10 @@ func updateShootDeletionTimeStamp(g *WithT, crClient client.Client, cluster *gar
 }
 
 func testProberShouldBeRemovedIfDeletionTimeStampIsSet(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion126, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	createCluster(g, crClient, cluster)
-	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sLesserThan127)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGracePeriod)
 	updateShootDeletionTimeStamp(g, crClient, cluster, shoot)
 	proberShouldNotBePresent(g, reconciler, cluster)
 	deleteClusterAndCheckIfProberRemoved(g, crClient, reconciler, cluster)
@@ -301,7 +302,7 @@ func testShootCreationNotComplete(g *WithT, crClient client.Client, reconciler *
 	}
 
 	for _, testCase := range testCases {
-		cluster, shoot, err := testutil.CreateClusterResource(1, shootKCMNodeMonitorGracePeriod, k8sVersion126, false)
+		cluster, shoot, err := testutil.CreateClusterResource(1, shootKCMNodeMonitorGracePeriod, false)
 		g.Expect(err).ToNot(HaveOccurred())
 		setShootLastOperationStatus(cluster, shoot, gardencorev1beta1.LastOperationTypeCreate, testCase.lastOpState)
 		createCluster(g, crClient, cluster)
@@ -315,7 +316,7 @@ func testShootCreationNotComplete(g *WithT, crClient client.Client, reconciler *
 }
 
 func testShootIsMigrating(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion127, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	createCluster(g, crClient, cluster)
 	setShootLastOperationStatus(cluster, shoot, gardencorev1beta1.LastOperationTypeMigrate, "")
@@ -325,10 +326,10 @@ func testShootIsMigrating(g *WithT, crClient client.Client, reconciler *Reconcil
 }
 
 func testShootRestoringIsNotComplete(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion126, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	createCluster(g, crClient, cluster)
-	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sLesserThan127)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGracePeriod)
 	// cluster migration starts
 	setShootLastOperationStatus(cluster, shoot, gardencorev1beta1.LastOperationTypeMigrate, "")
 	updateCluster(g, crClient, cluster)
@@ -341,25 +342,25 @@ func testShootRestoringIsNotComplete(g *WithT, crClient client.Client, reconcile
 }
 
 func testLastOperationIsRestoreAndSuccessful(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion127, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	setShootLastOperationStatus(cluster, shoot, gardencorev1beta1.LastOperationTypeRestore, gardencorev1beta1.LastOperationStateSucceeded)
 	createCluster(g, crClient, cluster)
-	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sGreaterEqual127)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGracePeriod)
 	deleteClusterAndCheckIfProberRemoved(g, crClient, reconciler, cluster)
 }
 
 func testLastOperationIsShootReconciliation(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, shoot, err := testutil.CreateClusterResource(1, nil, k8sVersion126, false)
+	cluster, shoot, err := testutil.CreateClusterResource(1, nil, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	setShootLastOperationStatus(cluster, shoot, gardencorev1beta1.LastOperationTypeReconcile, "")
 	createCluster(g, crClient, cluster)
-	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGraceDurationForK8sLesserThan127)
+	proberShouldBePresent(g, reconciler, cluster, defaultKCMNodeMonitorGracePeriod)
 	deleteClusterAndCheckIfProberRemoved(g, crClient, reconciler, cluster)
 }
 
 func testShootHasNoWorkers(g *WithT, crClient client.Client, reconciler *Reconciler) {
-	cluster, _, err := testutil.CreateClusterResource(0, nil, k8sVersion127, false)
+	cluster, _, err := testutil.CreateClusterResource(0, nil, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	createCluster(g, crClient, cluster)
 	proberShouldNotBePresent(g, reconciler, cluster)

--- a/controllers/cluster/clusterpredicate_test.go
+++ b/controllers/cluster/clusterpredicate_test.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
+const k8sVersion128 = "v1.28.0"
+
 func TestCreateAndDeletePredicateFunc(t *testing.T) {
 	tests := []struct {
 		title          string
@@ -50,7 +52,7 @@ func TestCreateAndDeletePredicateFunc(t *testing.T) {
 }
 
 func testCreatePredicateFunc(g *WithT, numWorkers int) bool {
-	cluster, _, err := test.CreateClusterResource(numWorkers, nil, true)
+	cluster, _, err := test.CreateClusterResource(numWorkers, nil, k8sVersion128, true)
 	g.Expect(err).ToNot(HaveOccurred())
 	e := event.CreateEvent{Object: cluster}
 	predicateFuncs := workerLessShoot(logr.Discard())
@@ -58,7 +60,7 @@ func testCreatePredicateFunc(g *WithT, numWorkers int) bool {
 }
 
 func testDeletePredicateFunc(g *WithT, numWorkers int) bool {
-	cluster, _, err := test.CreateClusterResource(numWorkers, nil, true)
+	cluster, _, err := test.CreateClusterResource(numWorkers, nil, k8sVersion128, true)
 	g.Expect(err).ToNot(HaveOccurred())
 	e := event.DeleteEvent{Object: cluster}
 	predicateFuncs := workerLessShoot(logr.Discard())
@@ -89,9 +91,9 @@ func TestUpdatePredicateFunc(t *testing.T) {
 }
 
 func testUpdatePredicateFunc(g *WithT, oldNumWorker, newNumWorkers int) bool {
-	oldCluster, _, err := test.CreateClusterResource(oldNumWorker, nil, true)
+	oldCluster, _, err := test.CreateClusterResource(oldNumWorker, nil, k8sVersion128, true)
 	g.Expect(err).ToNot(HaveOccurred())
-	newCluster, _, err := test.CreateClusterResource(newNumWorkers, nil, true)
+	newCluster, _, err := test.CreateClusterResource(newNumWorkers, nil, k8sVersion128, true)
 	g.Expect(err).ToNot(HaveOccurred())
 	e := event.UpdateEvent{
 		ObjectOld: oldCluster,
@@ -121,7 +123,7 @@ func TestShootHasWorkersForNonShootResource(t *testing.T) {
 
 func TestShootHasWorkersForInvalidShootResource(t *testing.T) {
 	g := NewWithT(t)
-	cluster, _, err := test.CreateClusterResource(0, nil, false)
+	cluster, _, err := test.CreateClusterResource(0, nil, k8sVersion128, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	seed := gardencorev1beta1.Seed{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/cluster/clusterpredicate_test.go
+++ b/controllers/cluster/clusterpredicate_test.go
@@ -27,8 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
-const k8sVersion128 = "v1.28.0"
-
 func TestCreateAndDeletePredicateFunc(t *testing.T) {
 	tests := []struct {
 		title          string
@@ -52,7 +50,7 @@ func TestCreateAndDeletePredicateFunc(t *testing.T) {
 }
 
 func testCreatePredicateFunc(g *WithT, numWorkers int) bool {
-	cluster, _, err := test.CreateClusterResource(numWorkers, nil, k8sVersion128, true)
+	cluster, _, err := test.CreateClusterResource(numWorkers, nil, true)
 	g.Expect(err).ToNot(HaveOccurred())
 	e := event.CreateEvent{Object: cluster}
 	predicateFuncs := workerLessShoot(logr.Discard())
@@ -60,7 +58,7 @@ func testCreatePredicateFunc(g *WithT, numWorkers int) bool {
 }
 
 func testDeletePredicateFunc(g *WithT, numWorkers int) bool {
-	cluster, _, err := test.CreateClusterResource(numWorkers, nil, k8sVersion128, true)
+	cluster, _, err := test.CreateClusterResource(numWorkers, nil, true)
 	g.Expect(err).ToNot(HaveOccurred())
 	e := event.DeleteEvent{Object: cluster}
 	predicateFuncs := workerLessShoot(logr.Discard())
@@ -91,9 +89,9 @@ func TestUpdatePredicateFunc(t *testing.T) {
 }
 
 func testUpdatePredicateFunc(g *WithT, oldNumWorker, newNumWorkers int) bool {
-	oldCluster, _, err := test.CreateClusterResource(oldNumWorker, nil, k8sVersion128, true)
+	oldCluster, _, err := test.CreateClusterResource(oldNumWorker, nil, true)
 	g.Expect(err).ToNot(HaveOccurred())
-	newCluster, _, err := test.CreateClusterResource(newNumWorkers, nil, k8sVersion128, true)
+	newCluster, _, err := test.CreateClusterResource(newNumWorkers, nil, true)
 	g.Expect(err).ToNot(HaveOccurred())
 	e := event.UpdateEvent{
 		ObjectOld: oldCluster,
@@ -123,7 +121,7 @@ func TestShootHasWorkersForNonShootResource(t *testing.T) {
 
 func TestShootHasWorkersForInvalidShootResource(t *testing.T) {
 	g := NewWithT(t)
-	cluster, _, err := test.CreateClusterResource(0, nil, k8sVersion128, false)
+	cluster, _, err := test.CreateClusterResource(0, nil, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	seed := gardencorev1beta1.Seed{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/cluster/testdata/prober-config.yaml
+++ b/controllers/cluster/testdata/prober-config.yaml
@@ -2,7 +2,6 @@ kubeConfigSecretName: "dwd-api-server-probe-secret"
 probeInterval: 20s
 initialDelay: 5s
 backOffJitterFactor: 0.2
-kcmNodeMonitorGraceDuration: 2m
 dependentResourceInfos:
   - ref:
       kind: "Deployment"

--- a/internal/prober/config.go
+++ b/internal/prober/config.go
@@ -42,6 +42,10 @@ const (
 	//		2. numberOfOwnedLeases = 10, numberOfExpiredLeases = 5.
 	//	 	   numberOfExpiredLeases/numberOfOwnedLeases = 0.5, which is < DefaultNodeLeaseFailureFraction and so the lease probe will succeed.
 	DefaultNodeLeaseFailureFraction = 0.60
+	// DefaultKCMNodeMonitorGraceDuration is set to the default value of nodeMonitorGracePeriod in KCM.
+	// See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#:~:text=%2D%2Dnode%2Dmonitor%2Dgrace%2Dperiod%20duration
+	// Note: Make sure to keep this value in sync with default value of nodeMonitorGracePeriod in KCM.
+	DefaultKCMNodeMonitorGraceDuration = 40 * time.Second
 )
 
 // LoadConfig reads the prober configuration from a file, unmarshalls it, fills in the default values and
@@ -84,6 +88,7 @@ func fillDefaultValues(c *papi.Config) {
 	c.ProbeTimeout = util.GetValOrDefault(c.ProbeTimeout, metav1.Duration{Duration: DefaultProbeTimeout})
 	c.BackoffJitterFactor = util.GetValOrDefault(c.BackoffJitterFactor, DefaultBackoffJitterFactor)
 	c.NodeLeaseFailureFraction = util.GetValOrDefault(c.NodeLeaseFailureFraction, DefaultNodeLeaseFailureFraction)
+	c.KCMNodeMonitorGraceDuration = util.GetValOrDefault(c.KCMNodeMonitorGraceDuration, metav1.Duration{Duration: DefaultKCMNodeMonitorGraceDuration})
 	fillDefaultValuesForResourceInfos(c.DependentResourceInfos)
 }
 

--- a/internal/prober/config.go
+++ b/internal/prober/config.go
@@ -63,7 +63,9 @@ func validate(c *papi.Config, scheme *runtime.Scheme) error {
 	v := new(util.Validator)
 	// Check the mandatory config parameters for which a default will not be set
 	v.MustNotBeEmpty("KubeConfigSecretName", c.KubeConfigSecretName)
-	v.MustNotBeZeroDuration("KCMNodeMonitorGraceDuration", c.KCMNodeMonitorGraceDuration)
+	if c.KCMNodeMonitorGraceDuration != nil {
+		v.MustNotBeZeroDuration("KCMNodeMonitorGraceDuration", *c.KCMNodeMonitorGraceDuration)
+	}
 	v.MustNotBeEmpty("ScaleResourceInfos", c.DependentResourceInfos)
 	for _, resInfo := range c.DependentResourceInfos {
 		v.ResourceRefMustBeValid(resInfo.Ref, scheme)

--- a/internal/prober/config_test.go
+++ b/internal/prober/config_test.go
@@ -84,8 +84,8 @@ func testMissingConfigValuesShouldReturnErrorAndNilConfig(t *testing.T, s *runti
 		fileName         string
 		expectedErrCount int
 	}{
-		{"config_missing_mandatory_values.yaml", 6},
-		{"config_missing_dependent_resource_infos.yaml", 3},
+		{"config_missing_mandatory_values.yaml", 5},
+		{"config_missing_dependent_resource_infos.yaml", 2},
 	}
 
 	for _, entry := range table {

--- a/internal/prober/config_test.go
+++ b/internal/prober/config_test.go
@@ -70,6 +70,7 @@ func testCheckIfDefaultValuesAreSetForAllOptionalMissingValues(t *testing.T, s *
 	g.Expect(config.ProbeInterval.Milliseconds()).To(Equal(DefaultProbeInterval.Milliseconds()), "LoadConfig should set probe delay to DefaultProbeInterval if not set in the config file")
 	g.Expect(*config.BackoffJitterFactor).To(Equal(DefaultBackoffJitterFactor), "LoadConfig should set jitter factor to DefaultJitterFactor if not set in the config file")
 	g.Expect(*config.NodeLeaseFailureFraction).To(Equal(DefaultNodeLeaseFailureFraction), "LoadConfig should set lease failure threshold fraction to DefaultNodeLeaseFailureFraction if not set in the config file")
+	g.Expect(config.KCMNodeMonitorGraceDuration.Milliseconds()).To(Equal(DefaultKCMNodeMonitorGraceDuration.Milliseconds()), "LoadConfig should set kcmNodeMonitorGraceDuration to DefaultKCMNodeMonitorGraceDuration if not set in the config file")
 	for _, resInfo := range config.DependentResourceInfos {
 		g.Expect(resInfo.ScaleUpInfo.InitialDelay.Milliseconds()).To(Equal(DefaultScaleInitialDelay.Milliseconds()), fmt.Sprintf("LoadConfig should set scale up initial delay for %v to DefaultInitialDelay if not set in the config file", resInfo.Ref.Name))
 		g.Expect(resInfo.ScaleUpInfo.Timeout.Milliseconds()).To(Equal(DefaultScaleUpdateTimeout.Milliseconds()), fmt.Sprintf("LoadConfig should set scale up timeout for %v to DefaultScaleUpTimeout if not set in the config file", resInfo.Ref.Name))

--- a/internal/prober/prober_test.go
+++ b/internal/prober/prober_test.go
@@ -219,7 +219,7 @@ func createConfig(probeInterval metav1.Duration, initialDelay metav1.Duration, k
 		BackoffJitterFactor:         &backoffJitterFactor,
 		InitialDelay:                &initialDelay,
 		ProbeTimeout:                &testProbeTimeout,
-		KCMNodeMonitorGraceDuration: kcmNodeMonitorGraceDuration,
+		KCMNodeMonitorGraceDuration: &kcmNodeMonitorGraceDuration,
 		NodeLeaseFailureFraction:    pointer.Float64(DefaultNodeLeaseFailureFraction),
 	}
 }

--- a/internal/prober/testdata/config_missing_voluntary_values.yaml
+++ b/internal/prober/testdata/config_missing_voluntary_values.yaml
@@ -1,5 +1,4 @@
 kubeConfigSecretName: "dwd-api-server-probe-secret"
-kCMNodeMonitorGraceDuration: 2m
 dependentResourceInfos:
   - ref:
       kind: "Deployment"

--- a/internal/test/cluster.go
+++ b/internal/test/cluster.go
@@ -28,7 +28,7 @@ import (
 
 // CreateClusterResource creates a test cluster and shoot resources.
 // This should only be used for unit testing.
-func CreateClusterResource(numWorkers int, nodeMonitorGracePeriod *metav1.Duration, k8sVersion string, rawShoot bool) (*gardenerv1alpha1.Cluster, *gardencorev1beta1.Shoot, error) {
+func CreateClusterResource(numWorkers int, nodeMonitorGracePeriod *metav1.Duration, rawShoot bool) (*gardenerv1alpha1.Cluster, *gardencorev1beta1.Shoot, error) {
 	cloudProfile := gardencorev1beta1.CloudProfile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "aws",
@@ -52,7 +52,7 @@ func CreateClusterResource(numWorkers int, nodeMonitorGracePeriod *metav1.Durati
 			},
 		},
 	}
-	shoot := CreateShoot(seed.Name, numWorkers, nodeMonitorGracePeriod, k8sVersion)
+	shoot := CreateShoot(seed.Name, numWorkers, nodeMonitorGracePeriod)
 	if rawShoot {
 		shootBytes, err := json.Marshal(shoot)
 		if err != nil {
@@ -67,7 +67,7 @@ func CreateClusterResource(numWorkers int, nodeMonitorGracePeriod *metav1.Durati
 
 // CreateShoot creates a shoot resources.
 // This should only be used for unit testing.
-func CreateShoot(seedName string, numWorkers int, nodeMonitorGracePeriod *metav1.Duration, k8sVersion string) gardencorev1beta1.Shoot {
+func CreateShoot(seedName string, numWorkers int, nodeMonitorGracePeriod *metav1.Duration) gardencorev1beta1.Shoot {
 	end := "00 08 * * 1,2,3,4,5"
 	start := "30 19 * * 1,2,3,4,5"
 	location := "Asia/Calcutta"
@@ -87,7 +87,6 @@ func CreateShoot(seedName string, numWorkers int, nodeMonitorGracePeriod *metav1
 				KubeControllerManager: &gardencorev1beta1.KubeControllerManagerConfig{
 					NodeMonitorGracePeriod: nodeMonitorGracePeriod,
 				},
-				Version: k8sVersion,
 			},
 			Provider: gardencorev1beta1.Provider{
 				Type:    "aws",

--- a/internal/test/cluster.go
+++ b/internal/test/cluster.go
@@ -28,7 +28,7 @@ import (
 
 // CreateClusterResource creates a test cluster and shoot resources.
 // This should only be used for unit testing.
-func CreateClusterResource(numWorkers int, nodeMonitorGracePeriod *metav1.Duration, rawShoot bool) (*gardenerv1alpha1.Cluster, *gardencorev1beta1.Shoot, error) {
+func CreateClusterResource(numWorkers int, nodeMonitorGracePeriod *metav1.Duration, k8sVersion string, rawShoot bool) (*gardenerv1alpha1.Cluster, *gardencorev1beta1.Shoot, error) {
 	cloudProfile := gardencorev1beta1.CloudProfile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "aws",
@@ -52,7 +52,7 @@ func CreateClusterResource(numWorkers int, nodeMonitorGracePeriod *metav1.Durati
 			},
 		},
 	}
-	shoot := CreateShoot(seed.Name, numWorkers, nodeMonitorGracePeriod)
+	shoot := CreateShoot(seed.Name, numWorkers, nodeMonitorGracePeriod, k8sVersion)
 	if rawShoot {
 		shootBytes, err := json.Marshal(shoot)
 		if err != nil {
@@ -67,7 +67,7 @@ func CreateClusterResource(numWorkers int, nodeMonitorGracePeriod *metav1.Durati
 
 // CreateShoot creates a shoot resources.
 // This should only be used for unit testing.
-func CreateShoot(seedName string, numWorkers int, nodeMonitorGracePeriod *metav1.Duration) gardencorev1beta1.Shoot {
+func CreateShoot(seedName string, numWorkers int, nodeMonitorGracePeriod *metav1.Duration, k8sVersion string) gardencorev1beta1.Shoot {
 	end := "00 08 * * 1,2,3,4,5"
 	start := "30 19 * * 1,2,3,4,5"
 	location := "Asia/Calcutta"
@@ -87,6 +87,7 @@ func CreateShoot(seedName string, numWorkers int, nodeMonitorGracePeriod *metav1
 				KubeControllerManager: &gardencorev1beta1.KubeControllerManagerConfig{
 					NodeMonitorGracePeriod: nodeMonitorGracePeriod,
 				},
+				Version: k8sVersion,
 			},
 			Provider: gardencorev1beta1.Provider{
 				Type:    "aws",
@@ -107,11 +108,11 @@ func CreateShoot(seedName string, numWorkers int, nodeMonitorGracePeriod *metav1
 func createWorkers(numWorkers int) []gardencorev1beta1.Worker {
 	workers := make([]gardencorev1beta1.Worker, 0, numWorkers)
 	for i := 0; i < numWorkers; i++ {
-		max := rand.Int31n(5)
+		mx := rand.Int31n(5)
 		w := gardencorev1beta1.Worker{
 			Name:    fmt.Sprintf("worker-pool-%d", i),
 			Machine: gardencorev1beta1.Machine{},
-			Maximum: max,
+			Maximum: mx,
 			Minimum: 1,
 		}
 		workers = append(workers, w)


### PR DESCRIPTION
**What this PR does / why we need it**:
Make `kcmNodeMonitorGraceDuration` optional and default its value based on shoot k8s version

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Make `kcmNodeMonitorGraceDuration` optional in the prober config and default its value based on shoot k8s version
```
