### PR TITLE
Cherry pick of `https://github.com/gardener/dependency-watchdog/pull/101`

### DIFF
--- a/api/prober/types.go
+++ b/api/prober/types.go
@@ -33,8 +33,8 @@ type Config struct {
 	BackoffJitterFactor *float64 `json:"backoffJitterFactor,omitempty"`
 	// DependentResourceInfos are the dependent resources that should be considered for scaling in case the shoot control API server cannot be reached via external domain
 	DependentResourceInfos []DependentResourceInfo `json:"dependentResourceInfos"`
-	// KCMNodeMonitorGraceDuration is the node-monitor-grace-period set in the kcm flags
-	KCMNodeMonitorGraceDuration metav1.Duration `json:"kcmNodeMonitorGraceDuration"`
+	// KCMNodeMonitorGraceDuration is the node-monitor-grace-period set in the kcm flags.
+	KCMNodeMonitorGraceDuration *metav1.Duration `json:"kcmNodeMonitorGraceDuration,omitempty"`
 	// NodeLeaseFailureFraction is used to determine the maximum number of leases that can be expired for a lease probe to succeed.
 	NodeLeaseFailureFraction *float64 `json:"nodeLeaseFailureFraction,omitempty"`
 }

--- a/controllers/cluster/cluster_controller.go
+++ b/controllers/cluster/cluster_controller.go
@@ -194,7 +194,7 @@ func (r *Reconciler) getEffectiveProbeConfig(shoot *v1beta1.Shoot, logger logr.L
 	kcmConfig := shoot.Spec.Kubernetes.KubeControllerManager
 	if kcmConfig != nil && kcmConfig.NodeMonitorGracePeriod != nil {
 		logger.Info("Using the NodeMonitorGracePeriod set in the shoot as KCMNodeMonitorGraceDuration in the probe config", "nodeMonitorGraceDuration", *kcmConfig.NodeMonitorGracePeriod)
-		probeConfig.KCMNodeMonitorGraceDuration = *kcmConfig.NodeMonitorGracePeriod
+		probeConfig.KCMNodeMonitorGraceDuration = kcmConfig.NodeMonitorGracePeriod
 	}
 	return &probeConfig
 }

--- a/controllers/cluster/testdata/prober-config.yaml
+++ b/controllers/cluster/testdata/prober-config.yaml
@@ -2,7 +2,6 @@ kubeConfigSecretName: "dwd-api-server-probe-secret"
 probeInterval: 20s
 initialDelay: 5s
 backOffJitterFactor: 0.2
-kcmNodeMonitorGraceDuration: 2m
 dependentResourceInfos:
   - ref:
       kind: "Deployment"

--- a/internal/prober/config.go
+++ b/internal/prober/config.go
@@ -42,6 +42,10 @@ const (
 	//		2. numberOfOwnedLeases = 10, numberOfExpiredLeases = 5.
 	//	 	   numberOfExpiredLeases/numberOfOwnedLeases = 0.5, which is < DefaultNodeLeaseFailureFraction and so the lease probe will succeed.
 	DefaultNodeLeaseFailureFraction = 0.60
+	// DefaultKCMNodeMonitorGraceDuration is set to the default value of nodeMonitorGracePeriod in KCM.
+	// See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#:~:text=%2D%2Dnode%2Dmonitor%2Dgrace%2Dperiod%20duration
+	// Note: Make sure to keep this value in sync with default value of nodeMonitorGracePeriod in KCM.
+	DefaultKCMNodeMonitorGraceDuration = 40 * time.Second
 )
 
 // LoadConfig reads the prober configuration from a file, unmarshalls it, fills in the default values and
@@ -63,7 +67,9 @@ func validate(c *papi.Config, scheme *runtime.Scheme) error {
 	v := new(util.Validator)
 	// Check the mandatory config parameters for which a default will not be set
 	v.MustNotBeEmpty("KubeConfigSecretName", c.KubeConfigSecretName)
-	v.MustNotBeZeroDuration("KCMNodeMonitorGraceDuration", c.KCMNodeMonitorGraceDuration)
+	if c.KCMNodeMonitorGraceDuration != nil {
+		v.MustNotBeZeroDuration("KCMNodeMonitorGraceDuration", *c.KCMNodeMonitorGraceDuration)
+	}
 	v.MustNotBeEmpty("ScaleResourceInfos", c.DependentResourceInfos)
 	for _, resInfo := range c.DependentResourceInfos {
 		v.ResourceRefMustBeValid(resInfo.Ref, scheme)
@@ -82,6 +88,7 @@ func fillDefaultValues(c *papi.Config) {
 	c.ProbeTimeout = util.GetValOrDefault(c.ProbeTimeout, metav1.Duration{Duration: DefaultProbeTimeout})
 	c.BackoffJitterFactor = util.GetValOrDefault(c.BackoffJitterFactor, DefaultBackoffJitterFactor)
 	c.NodeLeaseFailureFraction = util.GetValOrDefault(c.NodeLeaseFailureFraction, DefaultNodeLeaseFailureFraction)
+	c.KCMNodeMonitorGraceDuration = util.GetValOrDefault(c.KCMNodeMonitorGraceDuration, metav1.Duration{Duration: DefaultKCMNodeMonitorGraceDuration})
 	fillDefaultValuesForResourceInfos(c.DependentResourceInfos)
 }
 

--- a/internal/prober/config_test.go
+++ b/internal/prober/config_test.go
@@ -70,6 +70,7 @@ func testCheckIfDefaultValuesAreSetForAllOptionalMissingValues(t *testing.T, s *
 	g.Expect(config.ProbeInterval.Milliseconds()).To(Equal(DefaultProbeInterval.Milliseconds()), "LoadConfig should set probe delay to DefaultProbeInterval if not set in the config file")
 	g.Expect(*config.BackoffJitterFactor).To(Equal(DefaultBackoffJitterFactor), "LoadConfig should set jitter factor to DefaultJitterFactor if not set in the config file")
 	g.Expect(*config.NodeLeaseFailureFraction).To(Equal(DefaultNodeLeaseFailureFraction), "LoadConfig should set lease failure threshold fraction to DefaultNodeLeaseFailureFraction if not set in the config file")
+	g.Expect(config.KCMNodeMonitorGraceDuration.Milliseconds()).To(Equal(DefaultKCMNodeMonitorGraceDuration.Milliseconds()), "LoadConfig should set kcmNodeMonitorGraceDuration to DefaultKCMNodeMonitorGraceDuration if not set in the config file")
 	for _, resInfo := range config.DependentResourceInfos {
 		g.Expect(resInfo.ScaleUpInfo.InitialDelay.Milliseconds()).To(Equal(DefaultScaleInitialDelay.Milliseconds()), fmt.Sprintf("LoadConfig should set scale up initial delay for %v to DefaultInitialDelay if not set in the config file", resInfo.Ref.Name))
 		g.Expect(resInfo.ScaleUpInfo.Timeout.Milliseconds()).To(Equal(DefaultScaleUpdateTimeout.Milliseconds()), fmt.Sprintf("LoadConfig should set scale up timeout for %v to DefaultScaleUpTimeout if not set in the config file", resInfo.Ref.Name))
@@ -84,8 +85,8 @@ func testMissingConfigValuesShouldReturnErrorAndNilConfig(t *testing.T, s *runti
 		fileName         string
 		expectedErrCount int
 	}{
-		{"config_missing_mandatory_values.yaml", 6},
-		{"config_missing_dependent_resource_infos.yaml", 3},
+		{"config_missing_mandatory_values.yaml", 5},
+		{"config_missing_dependent_resource_infos.yaml", 2},
 	}
 
 	for _, entry := range table {

--- a/internal/prober/prober_test.go
+++ b/internal/prober/prober_test.go
@@ -219,7 +219,7 @@ func createConfig(probeInterval metav1.Duration, initialDelay metav1.Duration, k
 		BackoffJitterFactor:         &backoffJitterFactor,
 		InitialDelay:                &initialDelay,
 		ProbeTimeout:                &testProbeTimeout,
-		KCMNodeMonitorGraceDuration: kcmNodeMonitorGraceDuration,
+		KCMNodeMonitorGraceDuration: &kcmNodeMonitorGraceDuration,
 		NodeLeaseFailureFraction:    pointer.Float64(DefaultNodeLeaseFailureFraction),
 	}
 }

--- a/internal/prober/testdata/config_missing_voluntary_values.yaml
+++ b/internal/prober/testdata/config_missing_voluntary_values.yaml
@@ -1,5 +1,4 @@
 kubeConfigSecretName: "dwd-api-server-probe-secret"
-kCMNodeMonitorGraceDuration: 2m
 dependentResourceInfos:
   - ref:
       kind: "Deployment"

--- a/internal/test/cluster.go
+++ b/internal/test/cluster.go
@@ -107,11 +107,11 @@ func CreateShoot(seedName string, numWorkers int, nodeMonitorGracePeriod *metav1
 func createWorkers(numWorkers int) []gardencorev1beta1.Worker {
 	workers := make([]gardencorev1beta1.Worker, 0, numWorkers)
 	for i := 0; i < numWorkers; i++ {
-		max := rand.Int31n(5)
+		mx := rand.Int31n(5)
 		w := gardencorev1beta1.Worker{
 			Name:    fmt.Sprintf("worker-pool-%d", i),
 			Machine: gardencorev1beta1.Machine{},
-			Maximum: max,
+			Maximum: mx,
 			Minimum: 1,
 		}
 		workers = append(workers, w)


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick of `https://github.com/gardener/dependency-watchdog/pull/101`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator #101 @rishabh-11
Make `kcmNodeMonitorGraceDuration` optional in the prober config and use a default value of `40s` if not specified in the shoot and the config.
```
