### PR TITLE
Perform scale up if no candidate leases are present

### DIFF
--- a/internal/prober/prober_test.go
+++ b/internal/prober/prober_test.go
@@ -171,11 +171,13 @@ func TestAPIServerProbeShouldNotRunIfClientNotCreated(t *testing.T) {
 	createAndRunProber(t, testProbeInterval.Duration, config, mocks)
 }
 
-func TestScalingShouldNotHappenIfNoOwnedLeasesPresent(t *testing.T) {
+func TestScaleUpShouldHappenIfNoOwnedLeasesPresent(t *testing.T) {
 	entry := probeTestCase{
-		name:      "lease probe should reset if no owned lease is present",
-		leaseList: createNodeLeases(nil),
-		nodeList:  createNodes(0),
+		name:            "scale up should happen if no owned lease is present",
+		leaseList:       createNodeLeases(nil),
+		nodeList:        createNodes(0),
+		minScaleUpCount: 1,
+		maxScaleUpCount: math.MaxInt8,
 	}
 	mocks := createAndInitializeMocks(t, entry)
 	config := createConfig(testProbeInterval, metav1.Duration{Duration: time.Microsecond}, metav1.Duration{Duration: 40 * time.Second}, 0.2)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the code to performs scale up if no candidate leases are present

**Which issue(s) this PR fixes**:
Fixes #111 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Perform scale up if no candidate leases are present
```
