### PR TITLE
Update go version to `1.23`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -26,11 +26,11 @@ dependency-watchdog:
             dockerfile: 'Dockerfile'
     steps:
       check:
-        image: 'golang:1.22.2'
+        image: 'golang:1.23.3'
       test-unit:
-        image: 'golang:1.22.2'
+        image: 'golang:1.23.3'
       build:
-        image: 'golang:1.22.2'
+        image: 'golang:1.23.3'
         output_dir: 'binary'
   jobs:
     head-update:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.2 AS builder
+FROM golang:1.23.3 AS builder
 
 WORKDIR /go/src/github.com/gardener/dependency-watchdog
 COPY . .

--- a/cmd/.import-restrictions
+++ b/cmd/.import-restrictions
@@ -5,6 +5,7 @@ rules:
   - selectorRegexp: github[.]com/gardener
     allowedPrefixes:
       - github.com/gardener/gardener/pkg/apis
+      - github.com/gardener/machine-controller-manager/pkg/apis
   - selectorRegexp: github[.]com/gardener/dependency-watchdog
     allowedPrefixes:
     # should be self-contained and must not import any other dependency watchdog packages

--- a/controllers/cluster/cluster_controller_test.go
+++ b/controllers/cluster/cluster_controller_test.go
@@ -174,7 +174,7 @@ func testProberSharedEnvTest(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.title, func(t *testing.T) {
+		t.Run(test.title, func(_ *testing.T) {
 			test.run(g, crClient, reconciler)
 		})
 		deleteAllClusters(g, crClient)

--- a/controllers/endpoint/endpointpredicate.go
+++ b/controllers/endpoint/endpointpredicate.go
@@ -47,7 +47,7 @@ func ReadyEndpoints(logger logr.Logger) predicate.Predicate {
 			return false
 		},
 
-		DeleteFunc: func(event event.DeleteEvent) bool {
+		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return false
 		},
 
@@ -77,7 +77,7 @@ func MatchingEndpoints(epMap map[string]wapi.DependantSelectors) predicate.Predi
 			return isMatchingEndpoints(event.ObjectNew, epMap)
 		},
 
-		DeleteFunc: func(event event.DeleteEvent) bool {
+		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return false
 		},
 

--- a/controllers/endpoint/endpointpredicate_test.go
+++ b/controllers/endpoint/endpointpredicate_test.go
@@ -104,7 +104,7 @@ func TestReadyEndpoints(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(_ *testing.T) {
 			createEv := event.CreateEvent{
 				Object: tc.ep,
 			}
@@ -228,7 +228,7 @@ func TestMatchingEndpointsPredicate(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(_ *testing.T) {
 			createEv := event.CreateEvent{
 				Object: tc.ep,
 			}

--- a/controllers/endpoint/endpoints_controller_test.go
+++ b/controllers/endpoint/endpoints_controller_test.go
@@ -130,7 +130,7 @@ func testWeederSharedEnvTest(t *testing.T) {
 		childCtx, chileCancelFn := context.WithCancel(ctx)
 		testNs := rand.String(4)
 		testutil.CreateTestNamespace(childCtx, g, reconciler.Client, testNs)
-		t.Run(test.description, func(t *testing.T) {
+		t.Run(test.description, func(_ *testing.T) {
 			test.run(childCtx, chileCancelFn, g, reconciler, testNs)
 		})
 		deleteAllPods(childCtx, g, reconciler.Client)
@@ -154,7 +154,7 @@ func testWeederDedicatedEnvTest(t *testing.T) {
 		testEnv, reconciler := setupWeederEnv(ctx, t, test.apiServerFlags)
 		testNs := rand.String(4)
 		testutil.CreateTestNamespace(ctx, g, reconciler.Client, testNs)
-		t.Run(test.description, func(t *testing.T) {
+		t.Run(test.description, func(_ *testing.T) {
 			test.run(ctx, cancelFn, g, reconciler, testNs)
 		})
 		testutil.TeardownEnv(g, testEnv, cancelFn)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/dependency-watchdog
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/gardener/gardener v1.99.1
@@ -8,11 +8,14 @@ require (
 	github.com/go-logr/logr v1.4.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onsi/gomega v1.33.1
+	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.27.0
+	golang.org/x/tools v0.23.0
 	k8s.io/api v0.29.6
 	k8s.io/apimachinery v0.29.6
 	k8s.io/client-go v0.29.6
 	k8s.io/code-generator v0.29.6
+	k8s.io/klog/v2 v2.120.1
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.17.5
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231015215740-bf15e44028f9
@@ -81,7 +84,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
@@ -96,7 +98,6 @@ require (
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	golang.org/x/tools v0.23.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/protobuf v1.34.0 // indirect
@@ -110,7 +111,6 @@ require (
 	k8s.io/autoscaler/vertical-pod-autoscaler v1.1.2 // indirect
 	k8s.io/component-base v0.29.6 // indirect
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
-	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-aggregator v0.29.6 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	k8s.io/kubelet v0.29.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,14 +8,11 @@ require (
 	github.com/go-logr/logr v1.4.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onsi/gomega v1.33.1
-	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.27.0
-	golang.org/x/tools v0.23.0
 	k8s.io/api v0.29.6
 	k8s.io/apimachinery v0.29.6
 	k8s.io/client-go v0.29.6
 	k8s.io/code-generator v0.29.6
-	k8s.io/klog/v2 v2.120.1
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.17.5
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231015215740-bf15e44028f9
@@ -84,6 +81,7 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
@@ -98,6 +96,7 @@ require (
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/tools v0.23.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/protobuf v1.34.0 // indirect
@@ -111,6 +110,7 @@ require (
 	k8s.io/autoscaler/vertical-pod-autoscaler v1.1.2 // indirect
 	k8s.io/component-base v0.29.6 // indirect
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
+	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-aggregator v0.29.6 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	k8s.io/kubelet v0.29.6 // indirect

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -13,14 +13,14 @@ SETUP_ENVTEST     := $(TOOLS_BIN_DIR)/setup-envtest
 GOTESTFMT 	   	  := $(TOOLS_BIN_DIR)/gotestfmt
 
 #default tool versions
-GOLANGCI_LINT_VERSION ?= v1.55.2
+GOLANGCI_LINT_VERSION ?= v1.60.1
 GO_VULN_CHECK_VERSION ?= latest
 GOIMPORTS_VERSION ?= latest
-LOGCHECK_VERSION ?= cee120166b7b8a857dea90fc0217d86c2e41850f # this commit hash corresponds to v1.86.0 which is the gardener/gardener version in go.mod - we could use regular tags when https://github.com/gardener/gardener/issues/8811 is resolved
+LOGCHECK_VERSION ?= d8145718cbe49d7ea453091f7836804455afe56d # this commit hash corresponds to v1.99.1 which is the gardener/gardener version in go.mod - we could use regular tags when https://github.com/gardener/gardener/issues/8811 is resolved
 GO_ADD_LICENSE_VERSION ?= latest
 # import boss failing with latest , so pinning to most up-to-date successfull version
-# refer https://pkg.go.dev/k8s.io/code-generator@v0.26.3/cmd/import-boss?tab=versions for list of versions
-GO_IMPORT_BOSS_VERSION ?= v0.28.4 
+# refer https://pkg.go.dev/k8s.io/code-generator@v0.29.6/cmd/import-boss?tab=versions for list of versions
+GO_IMPORT_BOSS_VERSION ?= v0.28.4
 GO_STRESS_VERSION ?= latest
 SETUP_ENVTEST_VERSION ?= latest
 GOTESTFMT_VERSION ?= v2.5.0

--- a/internal/util/k8shelper.go
+++ b/internal/util/k8shelper.go
@@ -93,7 +93,7 @@ func createRestConfigFromKubeConfigBytes(kubeConfigBytes []byte, connectionTimeo
 	if err != nil {
 		return nil, err
 	}
-	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+	config.Wrap(func(_ http.RoundTripper) http.RoundTripper {
 		return transport
 	})
 	return config, nil

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -107,7 +107,7 @@ func TestGetSliceOrDefault(t *testing.T) {
 	g := NewWithT(t)
 	t.Parallel()
 	for _, test := range tests {
-		t.Run(test.description, func(t *testing.T) {
+		t.Run(test.description, func(_ *testing.T) {
 			g.Expect(GetSliceOrDefault(test.inputSlice, test.expectedOutputSlice)).To(Equal(test.expectedOutputSlice))
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Update go version to `1.23`. The e2e-test doc is also fixed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated the go version to 1.23.
```
