### PR TITLE
Introduce make targets for sast and address security issues.

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -40,4 +40,6 @@ fi
 
 make check
 
+make sast-report
+
 echo "All checks are passing."

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ dev
 hack/test
 .DS_Store
 .idea/
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -87,3 +87,11 @@ stress_args = test-package test-func tool-params
 .PHONY: stress
 stress: $(GO_STRESS)
 	@./hack/stress-test.sh $@ $(call args,$@)
+
+.PHONY: sast
+sast: $(GOSEC)
+	@./hack/sast.sh
+
+.PHONY: sast-report
+sast-report:$(GOSEC)
+	@./hack/sast.sh --gosec-report true

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# DWD uses code-generators https://github.com/kubernetes/code-generator which create lots of G103 (CWE-242:
+# Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+gosec -exclude-generated -exclude-dir=hack -exclude-dir=tmp $gosec_report_parse_flags ./...

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -35,10 +35,7 @@ if [[ "$gosec_report" != "false" ]]; then
   gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
 fi
 
-# DWD uses code-generators https://github.com/kubernetes/code-generator which create lots of G103 (CWE-242:
-# Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
-# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
-# Thus, generated code is excluded from gosec scan.
+# Generated code is excluded from gosec scan.
 # Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
 # is excluded too. It does not contain productive code anyway.
 gosec -exclude-generated -exclude-dir=hack -exclude-dir=tmp $gosec_report_parse_flags ./...

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -11,12 +11,13 @@ GO_IMPORT_BOSS    := $(TOOLS_BIN_DIR)/import-boss
 GO_STRESS         := $(TOOLS_BIN_DIR)/stress
 SETUP_ENVTEST     := $(TOOLS_BIN_DIR)/setup-envtest
 GOTESTFMT 	   	  := $(TOOLS_BIN_DIR)/gotestfmt
+GOSEC             := $(TOOLS_BIN_DIR)/gosec
 
 # Use this function to get the version of a go module from go.mod
 version_gomod = $(shell go list -mod=mod -f '{{ .Version }}' -m $(1))
 
 #default tool versions
-GOLANGCI_LINT_VERSION ?= v1.60.1
+GOLANGCI_LINT_VERSION ?= v1.60.3
 GO_VULN_CHECK_VERSION ?= latest
 GOIMPORTS_VERSION ?= latest
 LOGCHECK_VERSION ?= 282c229e4dc4b4088523b97a2a696a48e8506975 # this commit hash corresponds to v1.108.1 which is the gardener/gardener version in go.mod - we could use regular tags when https://github.com/gardener/gardener/issues/8811 is resolved
@@ -26,6 +27,7 @@ K8S_VERSION ?= $(subst v0,v1,$(call version_gomod,k8s.io/api))
 GO_STRESS_VERSION ?= latest
 SETUP_ENVTEST_VERSION ?= latest
 GOTESTFMT_VERSION ?= v2.5.0
+GOSEC_VERSION ?= v2.21.4
 
 # add ./hack/tools/bin to the PATH
 export TOOLS_BIN_DIR := $(TOOLS_BIN_DIR)
@@ -61,3 +63,6 @@ $(SETUP_ENVTEST):
 
 $(GOTESTFMT):
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@$(GOTESTFMT_VERSION)
+
+$(GOSEC):
+	GOSEC_VERSION=$(GOSEC_VERSION) bash $(TOOLS_DIR)/install-gosec.sh

--- a/hack/tools/install-gosec.sh
+++ b/hack/tools/install-gosec.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+echo "> Installing gosec"
+
+TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname $0)/bin}
+
+platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+version=$GOSEC_VERSION
+case $(uname -m) in
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  x86_64)
+    arch="amd64"
+    ;;
+  *)
+    echo "Unknown architecture"
+    exit -1
+    ;;
+esac
+
+archive_name="gosec_${version#v}_${platform}_${arch}"
+file_name="${archive_name}.tar.gz"
+
+temp_dir="$(mktemp -d)"
+function cleanup {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT ERR INT TERM
+curl -L -o ${temp_dir}/${file_name} "https://github.com/securego/gosec/releases/download/${version}/${file_name}"
+
+tar -xzm -C "${temp_dir}" -f "${temp_dir}/${file_name}"
+mv "${temp_dir}/gosec" $TOOLS_BIN_DIR
+chmod +x $TOOLS_BIN_DIR/gosec

--- a/internal/prober/errors/errors.go
+++ b/internal/prober/errors/errors.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package errors
 
 import "fmt"

--- a/internal/prober/fakes/k8s/discoveryclient.go
+++ b/internal/prober/fakes/k8s/discoveryclient.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package k8s
 
 import (

--- a/internal/prober/fakes/scale/scale.go
+++ b/internal/prober/fakes/scale/scale.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/internal/prober/fakes/shoot/clientcreator.go
+++ b/internal/prober/fakes/shoot/clientcreator.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package shoot
 
 import (

--- a/internal/prober/scaler/scale.go
+++ b/internal/prober/scaler/scale.go
@@ -171,11 +171,11 @@ func (r *resScaler) determineTargetReplicas(annotations map[string]string) (int3
 		return defaultScaleDownReplicas, nil
 	}
 	if replicasStr, ok := annotations[replicasAnnotationKey]; ok {
-		replicas, err := strconv.Atoi(replicasStr)
+		replicas, err := strconv.Atoi(replicasStr) // #nosec G109 -- replicas will not exceed MaxInt32
 		if err != nil {
 			return 0, fmt.Errorf("unexpected and invalid replicasStr set as value for annotation: %s for resource, Err: %w", replicasAnnotationKey, err)
 		}
-		return int32(replicas), nil
+		return int32(replicas), nil // #nosec G109 G115 -- number of replicas will not exceed MaxInt32
 	}
 	r.logger.Info("Replicas annotation not found, falling back to default scale-up replicas", "operation", r.resourceInfo.operation, "annotationKey", replicasAnnotationKey, "default-replicas", defaultScaleUpReplicas)
 	return defaultScaleUpReplicas, nil

--- a/internal/prober/types/types.go
+++ b/internal/prober/types/types.go
@@ -1,1 +1,5 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package types

--- a/internal/test/cluster.go
+++ b/internal/test/cluster.go
@@ -136,7 +136,7 @@ func createWorkers(workerCount int, workerNodeConditions [][]string) []gardencor
 		w := gardencorev1beta1.Worker{
 			Name:    rand.String(4),
 			Machine: gardencorev1beta1.Machine{},
-			Maximum: int32(mx),
+			Maximum: int32(mx), // #nosec G115 -- lies between 0 and 5.
 			Minimum: 1,
 		}
 		if i < len(workerNodeConditions) {

--- a/internal/test/constants.go
+++ b/internal/test/constants.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package test
 
 // DefaultNamespace is the default namespace used in tests

--- a/internal/test/k8sresources.go
+++ b/internal/test/k8sresources.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package test
 
 import (

--- a/internal/test/kind.go
+++ b/internal/test/kind.go
@@ -89,7 +89,7 @@ func CreateKindCluster(config KindConfig) (KindCluster, error) {
 		return nil, err
 	}
 	// store the kubeconfig file at kubeConfigPath, this will be later used to delete the cluster or perform operations on the cluster
-	err = os.WriteFile(kubeConfigPath, kubeConfigBytes, 0644)
+	err = os.WriteFile(kubeConfigPath, kubeConfigBytes, 0644) // #nosec G306 -- Test only
 	if err != nil {
 		return nil, fmt.Errorf("failed to store the kubeconfig file at %s :%w", kubeConfigPath, err)
 	}

--- a/internal/test/miscellaneous.go
+++ b/internal/test/miscellaneous.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package test
 
 import (

--- a/internal/test/miscellaneous.go
+++ b/internal/test/miscellaneous.go
@@ -12,7 +12,7 @@ import (
 
 // ReadFile reads the file present at the given filePath and returns a byte Buffer containing its contents.
 func ReadFile(filePath string) (*bytes.Buffer, error) {
-	f, err := os.Open(filePath)
+	f, err := os.Open(filePath) // #nosec G304 -- Test only
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/k8shelper.go
+++ b/internal/util/k8shelper.go
@@ -215,7 +215,7 @@ func GetResourceReadyReplicas(ctx context.Context, cli client.Client, namespace 
 		return 0, err
 	}
 
-	return int32(readyReplicas), nil
+	return int32(readyReplicas), nil // #nosec G115 -- number of replicas will not exceed MaxInt32
 }
 
 // CreateClientSetFromRestConfig creates a kubernetes.Clientset from rest.Config.

--- a/internal/util/node.go
+++ b/internal/util/node.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package util
 
 import (

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -26,7 +26,7 @@ func SleepWithContext(ctx context.Context, sleepFor time.Duration) error {
 
 // ReadAndUnmarshall reads file and Unmarshall the contents in a generic type
 func ReadAndUnmarshall[T any](filename string) (*T, error) {
-	configBytes, err := os.ReadFile(filename)
+	configBytes, err := os.ReadFile(filename) // #nosec G304 -- Loaded from ConfigMap
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces two make targets: `sast` and `sast-report` to run `gosec` for Static Application Security Testing. It also addresses the security issues in the repository. The `.ci/check` script now calls `make sast-report` to install and run `gosec`.

**Which issue(s) this PR fixes**:
Fixes #129 

**Special notes for your reviewer**:
No changes made to the implementation. Only comments added to suppress `gosec` warnings wherever appropriate.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Adding `gosec` for Static Application Security Testing (SAST).
```
