### PR TITLE
Log fraction of expired leases

### DIFF
--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -127,13 +127,14 @@ func (p *Prober) recordError(err error, code errors.ErrorCode, message string) {
 
 func (p *Prober) checkAndTriggerScale(ctx context.Context, candidateNodeLeases []coordinationv1.Lease) {
 	// revive:disable:early-return
-	if p.shouldPerformScaleUp(candidateNodeLeases) {
+	shouldScaleUp, expiredFraction := p.shouldPerformScaleUp(candidateNodeLeases)
+	if shouldScaleUp {
 		if err := p.scaler.ScaleUp(ctx); err != nil {
 			p.recordError(err, errors.ErrScaleUp, "Failed to scale up resources")
 			p.l.Error(err, "Failed to scale up resources")
 		}
 	} else {
-		p.l.Info("Lease probe failed, performing scale down operation if required")
+		p.l.Info("Lease probe failed, performing scale down operation if required", "expiredFraction", *expiredFraction, "threshold", *p.config.NodeLeaseFailureFraction)
 		if err := p.scaler.ScaleDown(ctx); err != nil {
 			p.recordError(err, errors.ErrScaleDown, "Failed to scale down resources")
 			p.l.Error(err, "Failed to scale down resources")
@@ -145,10 +146,10 @@ func (p *Prober) checkAndTriggerScale(ctx context.Context, candidateNodeLeases [
 
 // shouldPerformScaleUp returns true if the ratio of expired node leases to valid node leases is less than
 // the NodeLeaseFailureFraction set in the prober config
-func (p *Prober) shouldPerformScaleUp(candidateNodeLeases []coordinationv1.Lease) bool {
+func (p *Prober) shouldPerformScaleUp(candidateNodeLeases []coordinationv1.Lease) (bool, *float64) {
 	if len(candidateNodeLeases) == 0 {
 		p.l.Info("No owned node leases are present in the cluster, performing scale up operation if required")
-		return true
+		return true, nil
 	}
 	var expiredNodeLeaseCount float64
 	for _, lease := range candidateNodeLeases {
@@ -156,11 +157,12 @@ func (p *Prober) shouldPerformScaleUp(candidateNodeLeases []coordinationv1.Lease
 			expiredNodeLeaseCount++
 		}
 	}
-	shouldScaleUp := expiredNodeLeaseCount/float64(len(candidateNodeLeases)) < *p.config.NodeLeaseFailureFraction
+	expiredFraction := expiredNodeLeaseCount / float64(len(candidateNodeLeases))
+	shouldScaleUp := expiredFraction < *p.config.NodeLeaseFailureFraction
 	if shouldScaleUp {
-		p.l.Info("Lease probe succeeded, performing scale up operation if required")
+		p.l.Info("Lease probe succeeded, performing scale up operation if required", "expiredFraction", expiredFraction, "threshold", *p.config.NodeLeaseFailureFraction)
 	}
-	return shouldScaleUp
+	return shouldScaleUp, &expiredFraction
 }
 
 func (p *Prober) setupProbeClient(ctx context.Context) (client.Client, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the fraction of expired leases in the log messages. This improves the observability of DwD actions which is useful when debugging cluster issues

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
