### PR TITLE
Set the default logging to JSON from Console

### DIFF
--- a/dwd.go
+++ b/dwd.go
@@ -41,7 +41,7 @@ func main() {
 	checkArgs(args)
 	ctx := ctrl.SetupSignalHandler()
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 		Level:       zapcore.DebugLevel,
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently DWD logs with development mode set to true. 
As per the documentation for field `Development` in Options struct in controller runtime zap logger this defaults it to console format. 
```go
// Options contains all possible settings.
type Options struct {
	// Development configures the logger to use a Zap development config
	// (stacktraces on warnings, no sampling), otherwise a Zap production
	// config will be used (stacktraces on errors, sampling).
	Development bool
	// Encoder configures how Zap will encode the output.  Defaults to
	// console when Development is true and JSON otherwise
	Encoder zapcore.Encoder
```
Also there in the deployment there is a flag for zap-log-level which is set to INFO but it doesn't seem to have any effect 
```yaml
     - command:
        - /usr/local/bin/dependency-watchdog
        - prober
        - --config-file=/etc/dependency-watchdog/config/dep-config.yaml
        - --kube-api-qps=20.0
        - --kube-api-burst=100
        - --zap-log-level=INFO
        - --enable-leader-election=true
 ```

For now to make the logs more readable this PR just marks Development as false in the zap options. 
Overall the codebase has inconsistencies, like weeder doesn't pass any flag, but prober does. But the flags are not really consumed in a way which can reflect the desired effect in log output as I don't see logging done at different level other than Info or Error. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
default log fomat for prober is now set to `JSON` instead of `console`
```
