### PR TITLE
Adapted relese yaml with correct permission for GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,14 +12,23 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
     with:
       mode: release
+      run-tests: true
 
   release-to-github-and-bump:
     uses: gardener/cc-utils/.github/workflows/release.yaml@master
     needs:
       - build
     secrets: inherit
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
     with:
       release-commit-target: branch
       next-version: ${{ inputs.next-version }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add permission to release.yaml workflow for GitHub Actions. 

**Which issue(s) this PR fixes**:
Fixes #166 

**Special notes for your reviewer**:
It follows the pattern as seen with ETCD-Druid [release.yaml](https://github.com/gardener/etcd-druid/blame/master/.github/workflows/release.yaml)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
