### PR TITLE
Fixed the non-release with run tests

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -1,6 +1,9 @@
 name: Build
 on:
   push:
+    branches:
+      - master
+      - 'rel-**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed the issue with PR where its failing 
```yaml

Invalid workflow file: .github/workflows/non-release.yaml#L8
The workflow is not valid. .github/workflows/non-release.yaml (Line: 8, Col: 11): Input run-tests is required, but not provided while calling.

````
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
