### PR TITLE
fix: typo (occured -> occurred) in test helper

### DIFF
--- a/internal/test/miscellaneous.go
+++ b/internal/test/miscellaneous.go
@@ -37,7 +37,7 @@ func FileExistsOrFail(filepath string) {
 		log.Fatalf("%s does not exist. This should not have happened. Check testdata directory.\n", filepath)
 	}
 	if err != nil {
-		log.Fatalf("Error occured in finding file %s : %v", filepath, err)
+		log.Fatalf("Error occurred in finding file %s : %v", filepath, err)
 	}
 }
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Fixes 'occured' -> 'occurred' typo in internal/test/miscellaneous.go helper.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
String/comment-only change, no functional impact.

**Release note**:
```other operator
NONE
```
