### PR TITLE
fix: typo (recieved -> received) in config_test

### DIFF
--- a/internal/prober/config_test.go
+++ b/internal/prober/config_test.go
@@ -112,7 +112,7 @@ func testErrorInUnMarshallingYaml(t *testing.T, s *runtime.Scheme) {
 	config, err := LoadConfig(configPath, s)
 	g.Expect(err).To(HaveOccurred(), "LoadConfig should not give error for a valid config")
 	g.Expect(config).To(BeNil(), "LoadConfig should got nil config for a valid file")
-	g.Expect(err.Error()).To(ContainSubstring("cannot unmarshal string into Go struct field DependentResourceInfo.dependentResourceInfos.scaleUp"), "Wrong error recieved")
+	g.Expect(err.Error()).To(ContainSubstring("cannot unmarshal string into Go struct field DependentResourceInfo.dependentResourceInfos.scaleUp"), "Wrong error received")
 }
 
 func testValidConfigShouldPassAllValidations(t *testing.T, s *runtime.Scheme) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Fixes 'recieved' -> 'received' typo in internal/prober/config_test.go.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
String/comment-only change, no functional impact.

**Release note**:
```other operator
NONE
```
